### PR TITLE
Timetableのjsonを追加

### DIFF
--- a/app/src/main/assets/timetable.json
+++ b/app/src/main/assets/timetable.json
@@ -1,0 +1,3258 @@
+{
+  "status": "OK",
+  "sessions": [
+    {
+      "id": "944860",
+      "title": {
+        "ja": "共有と分離 ─ Compose Multiplatform “本番導入” の設計指針",
+        "en": "Sharing and Separation — Design Guidelines for Production Adoption of Compose Multiplatform"
+      },
+      "description": "Kotlin Multiplatform (KMP) は、ネットワーク通信やドメインロジックを Android / iOS で共通化し、Compose Multiplatform (CMP) はそのうえ UI までを共通化します。両者を組み合わせれば、アプリの大部分を単一のコードベースで開発できることが大きな魅力です。\r\n\r\nところが実プロダクトへの導入に踏み出すと\r\n・使いたいライブラリや SDK が KMP に非対応\r\n・OS 固有の API を直接呼びたい\r\n・一部の画面をネイティブ UI でリッチに作り込みたい\r\nといった理由で、 ”共有できない領域” が必ず現れます。\r\n\r\n本セッションでは、Android と iOS のエンジニアが共同登壇し、\r\n・プラットフォーム間でコードのどこを共有し、どこを分離するのか\r\n・開発速度 × ユーザ体験 を両立させる設計・実装パターン\r\nを具体例とともに紹介します。実際に CMP を採用して半年弱で Android / iOS 両アプリをリリースしたプロダクトを題材に解説します。\r\n\r\n予定しているトピック：\r\n・共有の最前線\r\n　CMP + KMP 対応ライブラリの活用でどこまで共通化できるか\r\n・分離のテクニック\r\n　・Kotlin × Swift の DI 設計\r\n　・KMP に非対応の SDK の安全な統合\r\n　・CMP + ネイティブ UI のハイブリッド実装\r\n・両プラットフォーム視点で見る落とし穴と回避策\r\n\r\nCMP 導入で必ずぶつかる ”共有できない領域” を見極め、必要に応じてコードを切り離すための指針をお伝えします。",
+      "i18nDesc": {
+        "ja": "Kotlin Multiplatform (KMP) は、ネットワーク通信やドメインロジックを Android / iOS で共通化し、Compose Multiplatform (CMP) はそのうえ UI までを共通化します。両者を組み合わせれば、アプリの大部分を単一のコードベースで開発できることが大きな魅力です。\n\nところが実プロダクトへの導入に踏み出すと\n・使いたいライブラリや SDK が KMP に非対応\n・OS 固有の API を直接呼びたい\n・一部の画面をネイティブ UI でリッチに作り込みたい\nといった理由で、 ”共有できない領域” が必ず現れます。\n\n本セッションでは、Android と iOS のエンジニアが共同登壇し、\n・プラットフォーム間でコードのどこを共有し、どこを分離するのか\n・開発速度 × ユーザ体験 を両立させる設計・実装パターン\nを具体例とともに紹介します。実際に CMP を採用して半年弱で Android / iOS 両アプリをリリースしたプロダクトを題材に解説します。\n\n予定しているトピック：\n・共有の最前線\n CMP + KMP 対応ライブラリの活用でどこまで共通化できるか\n・分離のテクニック\n ・Kotlin × Swift の DI 設計\n ・KMP に非対応の SDK の安全な統合\n ・CMP + ネイティブ UI のハイブリッド実装\n・両プラットフォーム視点で見る落とし穴と回避策\n\nCMP 導入で必ずぶつかる ”共有できない領域” を見極め、必要に応じてコードを切り離すための指針をお伝えします。",
+        "en": "Kotlin Multiplatform (KMP) lets you share network communication and domain logic between Android and iOS, while Compose Multiplatform (CMP) further unifies the UI layer. Combining the two enables you to develop most of an app in a single codebase—a major attraction.\n\nHowever, once you step into a real product, “non-shareable areas” inevitably emerge because:\n- The library or SDK you want to use is not KMP-compatible\n- You need to call OS-specific APIs directly\n- You want to craft some screens with rich native UI\n\nIn this session, Android and iOS engineers will co-present:\n- Which parts of the code should be shared and which should be separated between platforms\n- Design and implementation patterns that balance development speed with user experience\nAll topics are illustrated with concrete examples from a product that adopted CMP and released both Android and iOS apps in just under six months.\n\nPlanned topics:\n- Front lines in sharing\n How far you can unify code by leveraging CMP + KMP-ready libraries\n- Separation techniques\n - DI design across Kotlin × Swift\n - Safe integration of SDKs that do not support KMP\n - Hybrid implementations of CMP + native UI\n- Pitfalls and workarounds viewed from both platform perspectives\n\nWe will share guidelines for identifying the “non-shareable” areas you will inevitably encounter when adopting CMP and for isolating code where necessary.\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-11T12:20:00+09:00",
+      "endsAt": "2025-09-11T13:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "fe4b0ef0-4120-4dd1-a432-2525d4258cd7",
+        "66978d55-f1c2-465f-9c1c-402c4489d9c4"
+      ],
+      "roomId": 64802,
+      "targetAudience": "・Kotlin Multiplatform や Compose Multiplatform の導入に関心がある方\r\n・Kotlin Multiplatform や Compose Multiplatform でどこまでコードを共有できるか知りたい方\r\n・Kotlin Multiplatform や Compose Multiplatform を導入し、プラットフォーム固有の実装が原因で手が止まっている方",
+      "i18nTargetAudience": {
+        "ja": "・Kotlin Multiplatform や Compose Multiplatform の導入に関心がある方\n・Kotlin Multiplatform や Compose Multiplatform でどこまでコードを共有できるか知りたい方\n・Kotlin Multiplatform や Compose Multiplatform を導入し、プラットフォーム固有の実装が原因で手が止まっている方",
+        "en": "- Anyone interested in adopting Kotlin Multiplatform or Compose Multiplatform\n- Those who want to know how much code can actually be shared with Kotlin Multiplatform or Compose Multiplatform\n- Developers who have already introduced Kotlin Multiplatform or Compose Multiplatform but are stalled by platform-specific implementation issues"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361171,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "946715",
+      "title": {
+        "ja": "ComposeではないコードをCompose化する",
+        "en": "Composifying Your Not-Compose Code"
+      },
+      "description": "Often, when writing Compose code, we need to interact with code that does not support Compose. One sample of those it could be the Google Maps SDK, which does not provide out-of-the-box support for Compose. The Android Maps Compose library was written to overcome this limitation.\r\n\r\nIn this session, we will explain some of the techniques used to develop android-maps-compose, and provide a Compose interface for a library that did not originally support it. You\u0027ll learn how we leveraged interoperability techniques, such as the Android View bridge, to wrap non-Compose components, manage their lifecycles safely within Compose, and expose idiomatic, composable APIs to end users.\r\n\r\nWhether you\u0027re looking to wrap legacy UI code or offer a modern Compose interface on top of a traditional Android library, this talk will provide you with practical tools, design patterns, and architectural considerations to help you “composify” just about anything.",
+      "i18nDesc": {
+        "ja": "Composeを使ってUIを書いていると、しばしばComposeに対応していないコードと連携する必要があります。 その一例がGoogle Maps SDKで、同ライブラリはComposeに標準対応していません。 この制限を克服するために開発されたのがAndroid Maps Composeライブラリです。\n\nこのセッションでは、android-maps-composeの開発に用いたテクニックを紹介し、元々 Compose に対応していないライブラリに対して、どのようにして Composeのインタフェースを提供したのかを解説します。Android Viewブリッジのような相互運用技術を活用し、非Composeコンポーネントを安全にラップしてライフサイクルを管理し、ユーザーにとって使いやすいCompose APIをどのように設計したのかをお見せします。\n\nレガシーなUI コードをComposeでラップしたい方や、従来のAndroidライブラリに Composeのインターフェースを提供したい方にとって、様々なものをCompose化する際に役立つ実践的なツールや設計パターン、アーキテクチャの考え方を持ち帰っていただける内容となっています。\n\n（DroidKaigi実行委員会による翻訳）",
+        "en": "Often, when writing Compose code, we need to interact with code that does not support Compose. One sample of those it could be the Google Maps SDK, which does not provide out-of-the-box support for Compose. The Android Maps Compose library was written to overcome this limitation.\n\nIn this session, we will explain some of the techniques used to develop android-maps-compose, and provide a Compose interface for a library that did not originally support it. You\u0027ll learn how we leveraged interoperability techniques, such as the Android View bridge, to wrap non-Compose components, manage their lifecycles safely within Compose, and expose idiomatic, composable APIs to end users.\n\nWhether you\u0027re looking to wrap legacy UI code or offer a modern Compose interface on top of a traditional Android library, this talk will provide you with practical tools, design patterns, and architectural considerations to help you “composify” just about anything."
+      },
+      "startsAt": "2025-09-12T11:20:00+09:00",
+      "endsAt": "2025-09-12T12:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "2f606e32-997a-4b74-8420-76a47e7d66a3"
+      ],
+      "roomId": 64800,
+      "targetAudience": "Ideally the audience should have experience with Android Maps already, and Compose, to understand the techniques applied.",
+      "i18nTargetAudience": {
+        "ja": "Android MapsやJetpack Composeに触れたことがあると紹介する手法の理解がしやすいです",
+        "en": "Ideally the audience should have experience with Android Maps already, and Compose, to understand the techniques applied."
+      },
+      "language": "ENGLISH",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361169,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": true,
+        "en": false
+      }
+    },
+    {
+      "id": "944464",
+      "title": {
+        "ja": "Android開発者のためのGen AI",
+        "en": "Gen AI for Android Developers"
+      },
+      "description": "(English follows Japanese)\r\n今年のGoogle I/Oにて、弊社はAndroid端末上で動作する新しい生成AI技術を発表しました。本セッションでは、これらの技術の動作原理と、皆様のアプリでの活用方法について解説します。また、先月（8月）にリリースされた最新アップデートについても詳しくご紹介します。\r\n\r\n目次:\r\n序. なぜAndroidアプリで生成AIが必要なのか？\r\n\r\nI. Gemini Nano: Androidに最適化された最速の生成AI\r\n- Android開発者のためのプロンプトエンジニアリング入門\r\n- モバイルフレンドリーなプロンプトの書き方\r\n- MLKit GenAI API: 特定ユースケース向けAPIの活用方法\r\n- 未来はここに！Gemini Nanoの進化\r\n\r\nII. Gemma 3n: オープンモデルの活用\r\n- Gemmaの特徴と利点\r\n- Gemma基盤生成AIを支えるSDK\r\n- ICL \u0026 LoRA: アプリのニーズに合わせたファインチューニング戦略\r\n\r\nIII. その他\r\n- 伝統的機械学習 (Traditional ML)\r\n- H/W acceleration with LiteRT Next\r\n- Play Delivery: 大容量モデルの配布戦略\r\n\r\n\u003d\u003d\u003d\u003d\u003d\u003d\r\nAt I/O \u002725, we announced new Gen AI tech for Android devices. This session will explore how these technologies work and how you can leverage them in your apps. I will also detail the key updates released last month (Aug).\r\n\r\nIntroduction: Why Gen AI in Your Android Apps?\r\n\r\nI. Gemini Nano: The fastest On-Device Gen AI model on Android\r\n- Prompt Engineering 101 for Android Developers\r\n- How to Write Mobile-friendly Prompts\r\n- Using the ML Kit GenAI API for Specific Use Cases\r\n- The Future is Now: The Evolution of Gemini Nano\r\n\r\nII. Gemma 3n: Leveraging Open Models\r\n- Why Choose Gemma?\r\n- SDKs for Gemma-Based Gen AI\r\n- ICL \u0026 LoRA: Fine-Tuning Strategies for Your App\u0027s Needs\r\n\r\nIII. Last, but definitely not least\r\n- Traditional Machine Learning in 2025\r\n- H/W Acceleration with LiteRT Next\r\n- Play Delivery: Distribution Strategies for Large-Scale Models",
+      "i18nDesc": {
+        "ja": "(English follows Japanese)\n今年のGoogle I/Oにて、弊社はAndroid端末上で動作する新しい生成AI技術を発表しました。本セッションでは、これらの技術の動作原理と、皆様のアプリでの活用方法について解説します。また、先月（8月）にリリースされた最新アップデートについても詳しくご紹介します。\n\n目次:\n序. なぜAndroidアプリで生成AIが必要なのか？\n\nI. Gemini Nano: Androidに最適化された最速の生成AI\n- Android開発者のためのプロンプトエンジニアリング入門\n- モバイルフレンドリーなプロンプトの書き方\n- MLKit GenAI API: 特定ユースケース向けAPIの活用方法\n- 未来はここに！Gemini Nanoの進化\n\nII. Gemma 3n: オープンモデルの活用\n- Gemmaの特徴と利点\n- Gemma基盤生成AIを支えるSDK\n- ICL \u0026 LoRA: アプリのニーズに合わせたファインチューニング戦略\n\nIII. その他\n- 伝統的機械学習 (Traditional ML)\n- H/W acceleration with LiteRT Next\n- Play Delivery: 大容量モデルの配布戦略\n\n\u003d\u003d\u003d\u003d\u003d\u003d\nAt I/O \u002725, we announced new Gen AI tech for Android devices. This session will explore how these technologies work and how you can leverage them in your apps. I will also detail the key updates released last month (Aug).\n\nIntroduction: Why Gen AI in Your Android Apps?\n\nI. Gemini Nano: The fastest On-Device Gen AI model on Android\n- Prompt Engineering 101 for Android Developers\n- How to Write Mobile-friendly Prompts\n- Using the ML Kit GenAI API for Specific Use Cases\n- The Future is Now: The Evolution of Gemini Nano\n\nII. Gemma 3n: Leveraging Open Models\n- Why Choose Gemma?\n- SDKs for Gemma-Based Gen AI\n- ICL \u0026 LoRA: Fine-Tuning Strategies for Your App\u0027s Needs\n\nIII. Last, but definitely not least\n- Traditional Machine Learning in 2025\n- H/W Acceleration with LiteRT Next\n- Play Delivery: Distribution Strategies for Large-Scale Models",
+        "en": "At I/O \u002725, we announced new Gen AI tech for Android devices. This session will explore how these technologies work and how you can leverage them in your apps. I will also detail the key updates released last month (Aug).\n\nIntroduction: Why Gen AI in Your Android Apps?\n\nI. Gemini Nano: The fastest On-Device Gen AI model on Android\n- Prompt Engineering 101 for Android Developers\n- How to Write Mobile-friendly Prompts\n- Using the ML Kit GenAI API for Specific Use Cases\n- The Future is Now: The Evolution of Gemini Nano\n\nII. Gemma 3n: Leveraging Open Models\n- Why Choose Gemma?\n- SDKs for Gemma-Based Gen AI\n- ICL \u0026 LoRA: Fine-Tuning Strategies for Your App\u0027s Needs\n\nIII. Last, but definitely not least\n- Traditional Machine Learning in 2025\n- H/W Acceleration with LiteRT Next\n- Play Delivery: Distribution Strategies for Large-Scale Models"
+      },
+      "startsAt": "2025-09-11T14:20:00+09:00",
+      "endsAt": "2025-09-11T15:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "ee3c097b-5c30-47e1-b311-59fb70a9724f"
+      ],
+      "roomId": 64801,
+      "targetAudience": "- Android開発一筋…だったけど、最近の生成AIが熱すぎて少しソワソワしている方\r\n- GoogleのAIソリューションが多すぎる(Gemini Nano, Gemma Nano, TensorFlow Lite / LiteRT, MLKit / MLKit Gen API, MediaPipe solutions/ MediaPipe Inference API, Google AI Edge SDKs, etc.)のでギブアップしそうになっていた方\r\n- AIを用いた機能の実装を検討している方\r\n- 一応、基本的なKotlinの文法は知っている方",
+      "i18nTargetAudience": {
+        "ja": "- Android開発一筋…だったけど、最近の生成AIが熱すぎて少しソワソワしている方\n- GoogleのAIソリューションが多すぎる(Gemini Nano, Gemma Nano, TensorFlow Lite / LiteRT, MLKit / MLKit Gen API, MediaPipe solutions/ MediaPipe Inference API, Google AI Edge SDKs, etc.)のでギブアップしそうになっていた方\n- AIを用いた機能の実装を検討している方\n- 一応、基本的なKotlinの文法は知っている方",
+        "en": "- Those who have been devoted to Android development…but feeling a bit restless with the recent surge in generative AI\n- Those about to give up because Google has too many AI solutions (Gemini Nano, Gemma Nano, TensorFlow Lite / LiteRT, MLKit / MLKit Gen API, MediaPipe solutions / MediaPipe Inference API, Google AI Edge SDKs, etc.)\n- Those considering implementing AI-powered features\n- Those who have at least a basic understanding of Kotlin syntax"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361170,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": false
+      }
+    },
+    {
+      "id": "38daa5fc-5d32-4f1f-9eb1-b67a1152f8d9",
+      "title": {
+        "ja": "特定のテーマで話せるミートアップ",
+        "en": "Themed Meetups"
+      },
+      "description": "様々なテーマごとに集まって、ランチやおやつを食べながら交流しましょう。\nテーマは開催時間ごとに違うものをご用意しています。興味があるテーマを見つけてぜひご参加ください。\n席に限りがありますので、参加を希望される方はお時間になりましたらお早めにお越しください。なお、ランチタイムのミートアップにはお弁当受け取り後にお越しください。\n\n9/11(木) 13:00-14:20：女性、English Speaking、首都圏以外から参加\n9/12(金) 13:00-14:20：Android初学者、一人で開発、子育てと仕事\n9/12(金) 16:20-17:00：AI活用、マネジメント、キャリアプラン",
+      "i18nDesc": {
+        "ja": "様々なテーマごとに集まって、ランチやおやつを食べながら交流しましょう。\nテーマは開催時間ごとに違うものをご用意しています。興味があるテーマを見つけてぜひご参加ください。\n席に限りがありますので、参加を希望される方はお時間になりましたらお早めにお越しください。なお、ランチタイムのミートアップにはお弁当受け取り後にお越しください。\n\n9/11(木) 13:00-14:20：女性、English Speaking、首都圏以外から参加\n9/12(金) 13:00-14:20：Android初学者、一人で開発、子育てと仕事\n9/12(金) 16:20-17:00：AI活用、マネジメント、キャリアプラン",
+        "en": "Let\u0027s gather around various themes and engage in conversations over lunch or snacks. Each session features a different theme, so find one that interests you and join us!\nPlease note that seating is limited. If you wish to participate, kindly arrive promptly at the scheduled time. For lunch-time meetups, please pick up your lunch before joining.\n\nThu, 11 Sep 2025 13:00-14:20 : Women, English Speaking, Participating from outside the Tokyo metropolitan area\nFri, 12 Sep 2025 13:00-14:20 : Android Beginners, Solo Developer, Parenting and Work\nFri, 12 Sep 2025 16:20-17:00 : AI utilization, Management, Career Plans"
+      },
+      "startsAt": "2025-09-12T16:20:00+09:00",
+      "endsAt": "2025-09-12T17:00:00+09:00",
+      "isServiceSession": true,
+      "isPlenumSession": false,
+      "speakers": [],
+      "roomId": 64803,
+      "targetAudience": "TBW",
+      "i18nTargetAudience": {
+        "ja": "TBW",
+        "en": "TBW"
+      },
+      "language": "MIXED",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361173,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "BEGINNER",
+        "INTERMEDIATE",
+        "ADVANCED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": true,
+        "en": true
+      }
+    },
+    {
+      "id": "943845",
+      "title": {
+        "ja": "ひとつの機能、ふたつの道筋：ソロで進むか、AI Copilotと共に行くか",
+        "en": "One Feature, Two Timelines: Flying Solo or with an AI Copilot"
+      },
+      "description": "Two years ago, I worked on a visually challenging feature in an Android project. This feature involved a wide variety of animations, a custom collision detection algorithm, and the need to maintain acceptable performance across a wide range of devices. The development process was bumpy and quite long — and ultimately costly for the project.\r\nBut what if I hadn’t been alone with Android Studio? How much time and effort could I have saved with a Copilot by my side?\r\nThis talk isn’t about promoting or rejecting AI tools. It’s a side-by-side comparison between the actual development of a real-world feature, and what it could have been like with a bit of AI assistance.\r\nI’ll walk you through the original implementation: the technical challenges, the decisions made, and the time it took. Then, I’ll rebuild a similar feature using AI tools like GitHub Copilot — highlighting the pros, the cons, and whether it’s worth the hype.\r\nLet’s face the changes AI is bringing to our daily work, and explore where — and how — it could actually be useful, through this hands-on case study.",
+      "i18nDesc": {
+        "ja": "2年前、私は Android プロジェクトで視覚的に難易度の高い機能開発に携わりました。この機能には、多種多様なアニメーション、独自の衝突検出アルゴリズム、そして多様なデバイスでパフォーマンスを維持する必要がありました。開発は長期に渡り難航し、最終的にプロジェクトにとって大きなコストとなりました。\nしかしながら、もし Android Studio と自分だけではなく、Copilot（AIアシスタント）がそばにいたらどうだったでしょう？どれだけの時間と労力を節約できたでしょうか？\n本講演は AI ツールを推進するためでも否定するためでもありません。これは、実際の機能開発と、AI支援があった場合とを並行して比較する試みです。\nまず、オリジナル実装を振り返りながら、技術的チャレンジ、下した判断、かかった時間についてお話しします。そして、GitHub Copilot などの AI ツールを用いて似たような機能を再実装し、そのメリットやデメリット、そして本当に期待に値するのかを検証します。\nAI が日々の開発にもたらす変化を直視し、そして実際のケーススタディを通して、どこで、どのようにAI支援が役立つのかを探っていきましょう。\n\n（DroidKaigi実行委員会による翻訳）",
+        "en": "Two years ago, I worked on a visually challenging feature in an Android project. This feature involved a wide variety of animations, a custom collision detection algorithm, and the need to maintain acceptable performance across a wide range of devices. The development process was bumpy and quite long — and ultimately costly for the project.\nBut what if I hadn’t been alone with Android Studio? How much time and effort could I have saved with a Copilot by my side?\nThis talk isn’t about promoting or rejecting AI tools. It’s a side-by-side comparison between the actual development of a real-world feature, and what it could have been like with a bit of AI assistance.\nI’ll walk you through the original implementation: the technical challenges, the decisions made, and the time it took. Then, I’ll rebuild a similar feature using AI tools like GitHub Copilot — highlighting the pros, the cons, and whether it’s worth the hype.\nLet’s face the changes AI is bringing to our daily work, and explore where — and how — it could actually be useful, through this hands-on case study."
+      },
+      "startsAt": "2025-09-11T12:20:00+09:00",
+      "endsAt": "2025-09-11T13:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "c3226ef8-4784-4a3c-a83d-6b70c0dcde1d"
+      ],
+      "roomId": 64801,
+      "targetAudience": "People who:\r\nDevelop Android specific features\r\nWant to learn from real-case experience\r\nAsk themself questions around AI position in our daily work life\r\n",
+      "i18nTargetAudience": {
+        "ja": "Android 向けに具体的な機能開発を行っている方\n\n実際のケースから学びたい方\n\n日々の開発における AI の位置づけについて考えている方",
+        "en": "People who:\nDevelop Android specific features\nWant to learn from real-case experience\nAsk themself questions around AI position in our daily work life"
+      },
+      "language": "ENGLISH",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361166,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": true,
+        "en": false
+      }
+    },
+    {
+      "id": "945988",
+      "title": {
+        "ja": "プロパティベーステストによるUIテスト: LLMによるプロパティ定義生成でエッジケースを捉える",
+        "en": "Property-Based Testing for UI: Capturing Edge Cases via LLM-Generated Property Definitions"
+      },
+      "description": "Jetpack Composeは、AndroidのUI開発に宣言的なアプローチを広く浸透させ、開発スタイルに大きな変化をもたらしました。しかし、UIテストの領域に目を向けると、Compose登場以前から存在する多くの根深い課題——プレビュー環境と実機動作間の微妙な差異、リファクタリング時の広範な影響範囲、そして無数の状態組み合わせや予期せぬ入力パターンから生じるエッジケースの不具合など——は依然として開発者を悩ませ続けています。\r\n\r\nこれらの網羅的な検証を、従来型の具体例ベースのテストや手動確認のみで効率的かつ効果的に行うことの難しさは、多くの開発現場で認識されていることかと思います。\r\n\r\n本セッションでは、この課題に対して「プロパティベーステスト（PBT）」をどのように活かせるか解説します。\r\n\r\nPBTは「どのような入力に対しても、常に満たすべき性質（プロパティ）」を定義し、予期せぬケースを自動で探し出す手法であり、元来アルゴリズムやビジネスロジックの検証でその力を発揮するものでした。\r\n\r\nKotlinでのPBT実践（Kotest / jqwik）の基本を押さえつつ、ViewModel内のロジックはもちろん、UIコンポーネント自体が持つべき「あるべき姿」をプロパティとして捉え、テストするためのアプローチやアイデアをお話します。 UIレイヤー特有の課題にPBTの原則をどう適用し挑むか、そしてLLMを活用した将来的なプロパティ定義の可能性についても実現可能性を探ります。\r\n\r\nPBTを通じてAndroidアプリの品質向上を目指すための新たな視点やヒントを提供することを目指します。\r\n\r\n具体的には以下のようなトピックを紹介する予定です。\r\n- UIテストにおける課題の再認識\r\n- プロパティベーステスト（PBT）の基本とUIテストへの応用可能性\r\n- UIにおける「性質（プロパティ）」の見つけ方、定義の勘所\r\n- マークダウン/ YAML形式による仕様書の管理とLLMを活用したプロパティ定義の自動生成\r\n- PBTのUIテストへの適用における限界と、その対策・補完戦略\r\n- PBTが失敗ケースを発見した際のデバッグ戦略と根本原因の特定",
+      "i18nDesc": {
+        "ja": "Jetpack Composeは、AndroidのUI開発に宣言的なアプローチを広く浸透させ、開発スタイルに大きな変化をもたらしました。しかし、UIテストの領域に目を向けると、Compose登場以前から存在する多くの根深い課題——プレビュー環境と実機動作間の微妙な差異、リファクタリング時の広範な影響範囲、そして無数の状態組み合わせや予期せぬ入力パターンから生じるエッジケースの不具合など——は依然として開発者を悩ませ続けています。\n\nこれらの網羅的な検証を、従来型の具体例ベースのテストや手動確認のみで効率的かつ効果的に行うことの難しさは、多くの開発現場で認識されていることかと思います。\n\n本セッションでは、この課題に対して「プロパティベーステスト（PBT）」をどのように活かせるか解説します。\n\nPBTは「どのような入力に対しても、常に満たすべき性質（プロパティ）」を定義し、予期せぬケースを自動で探し出す手法であり、元来アルゴリズムやビジネスロジックの検証でその力を発揮するものでした。\n\nKotlinでのPBT実践（Kotest / jqwik）の基本を押さえつつ、ViewModel内のロジックはもちろん、UIコンポーネント自体が持つべき「あるべき姿」をプロパティとして捉え、テストするためのアプローチやアイデアをお話します。 UIレイヤー特有の課題にPBTの原則をどう適用し挑むか、そしてLLMを活用した将来的なプロパティ定義の可能性についても実現可能性を探ります。\n\nPBTを通じてAndroidアプリの品質向上を目指すための新たな視点やヒントを提供することを目指します。\n\n具体的には以下のようなトピックを紹介する予定です。\n- UIテストにおける課題の再認識\n- プロパティベーステスト（PBT）の基本とUIテストへの応用可能性\n- UIにおける「性質（プロパティ）」の見つけ方、定義の勘所\n- マークダウン/ YAML形式による仕様書の管理とLLMを活用したプロパティ定義の自動生成\n- PBTのUIテストへの適用における限界と、その対策・補完戦略\n- PBTが失敗ケースを発見した際のデバッグ戦略と根本原因の特定",
+        "en": "Jetpack Compose has popularized a declarative approach to Android UI development, fundamentally changing how we build apps. Yet when we turn to the realm of UI testing, long-standing pain points that pre-date Compose—subtle gaps between preview and on-device behavior, wide-ranging ripple effects from refactors, and bugs emerging from countless state permutations and unexpected input patterns—continue to plague developers.\n\nTrying to achieve comprehensive coverage with conventional example-based tests and manual verification alone is notoriously difficult and inefficient in many teams.\n\nThis session explains how Property-Based Testing (PBT) can tackle these challenges. \n\nPBT defines “properties” that must always hold for every input, then automatically searches for counter-examples. While traditionally used for algorithms and business logic, we will show how its principles extend to the UI layer.\n\nAfter reviewing PBT basics in Kotlin (Kotest / jqwik), we discuss how to view not only ViewModel logic but also UI components themselves as subjects that must satisfy well-formed properties. We present concrete techniques for discovering and encoding those properties, demonstrate managing specs in Markdown/YAML, and explore a future workflow where LLMs generate property definitions to surface edge cases swiftly.\n\nAttendees will gain new perspectives and practical hints for improving Android app quality through PBT.\n\nWe plan to cover topics such as:\n- Re-examining the unique challenges of UI testing\n- Fundamentals of Property-Based Testing and its applicability to UI\n- Strategies for discovering and formulating UI “properties”\n- Managing specs in Markdown/YAML and auto-generating properties with LLMs\n- Practical limits of PBT in UI testing and complementary mitigation strategies\n- Debugging workflows and root-cause analysis when PBT uncovers failures\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-11T15:20:00+09:00",
+      "endsAt": "2025-09-11T16:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "87588dce-d45b-42fd-b77b-ae20e401bc53"
+      ],
+      "roomId": 64800,
+      "targetAudience": "- プロパティベーステストに興味がある方\r\n- 初級から上級のAndroid開発者\r\n- Android アプリのUIテスト自動化を推進している方",
+      "i18nTargetAudience": {
+        "ja": "- プロパティベーステストに興味がある方\n- 初級から上級のAndroid開発者\n- Android アプリのUIテスト自動化を推進している方",
+        "en": "- Anyone interested in Property-Based Testing\n- Android developers from beginner to advanced levels\n- Professionals promoting UI test automation for Android apps"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361165,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "935202",
+      "title": {
+        "ja": "Performance for Conversion! 分散トレーシングでボトルネックを特定せよ",
+        "en": "Performance for Conversion! Identifying Bottlenecks with Distributed Tracing"
+      },
+      "description": "Androidアプリにおいて、起動のもたつきやスクロールのカクつきは、ユーザーの離脱やCVR低下に直結する重大な課題です。しかし、プロジェクトが複雑になるにつれて、Firebase Performance Monitoring などの一般的な手法では、「なぜパフォーマンス指標が落ちているのか」「どこがボトルネックなのか」を突き止めるのが難しくなります。\r\n\r\nたとえば、画面の初期状態が表示されるまでの時間（Time to First Frame）が遅い場合、Data層の処理実行や画像のデコードが遅延していると思われがちですが、実際には、TCPコネクションの確立やCDN経由でのDNS解決など、アプリの外側の非同期処理が真因であるケースもあります。また、I/Oの詰まりがパフォーマンスの不具合に繋がる場合があり、必ずしもネットワークそのものが原因とは限らないため、手元で再現できないボトルネックの調査は非常に困難です。\r\n\r\n本セッションでは、バックエンドで広く使われている「分散トレーシング（Distributed Tracing）」の概要と、それをAndroidアプリでどのように活用できるかを解説します。また、pixivアプリが世界中の多様な環境のユーザーから愛用される中で、高品質を維持するために、アプリ内の処理とシステム処理の因果関係を明らかにし、パフォーマンスの問題を特定しやすくする手法や、モニタリングの工夫についても紹介します。\r\n\r\nさらに、Firebase Performance や Systrace との違いを踏まえながら、OpenTelemetry を使ったトレーシングの設計・運用、モバイル向けにカスタマイズした SDK の実装例、そして実際の改善事例を交えて、「読み込みが遅い」の正体をつかむための技術と仕組みをわかりやすくお伝えします。\r\n\r\n想定目次\r\n\r\n- なぜ従来の手法ではパフォーマンスの原因を特定が難しいのか\r\n- 分散トレーシングとは？\r\n    - Trace / Span / Context Propagation の基本概念\r\n    - OpenTelemetry とそのエコシステム\r\n    - Firebase Performance, Systrace との比較\r\n- Androidアプリ向け分散トレーシングの設計と導入\r\n    - 測定単位の粒度\r\n    - モバイル向け軽量SDKの設計と実装例\r\n    - データ収集とサンプリング\r\n- 可視化と運用\r\n    - Grafana等を用いた観測方法\r\n    - アラート設計のベストプラクティス\r\n- 課題解決フローと導入効果\r\n    - パフォーマンス問題解決フローの実例：観測→パフォーマンス指標の遅延→調査→改善→観測\r\n- 考察と展望\r\n    - 導入前後での開発プロセスの変化\r\n    - 分散トレーシングの持つ将来的な可能性（AIと連携したモニタリングについてなど）",
+      "i18nDesc": {
+        "ja": "Androidアプリにおいて、起動のもたつきやスクロールのカクつきは、ユーザーの離脱やCVR低下に直結する重大な課題です。しかし、プロジェクトが複雑になるにつれて、Firebase Performance Monitoring などの一般的な手法では、「なぜパフォーマンス指標が落ちているのか」「どこがボトルネックなのか」を突き止めるのが難しくなります。\n\nたとえば、画面の初期状態が表示されるまでの時間（Time to First Frame）が遅い場合、Data層の処理実行や画像のデコードが遅延していると思われがちですが、実際には、TCPコネクションの確立やCDN経由でのDNS解決など、アプリの外側の非同期処理が真因であるケースもあります。また、I/Oの詰まりがパフォーマンスの不具合に繋がる場合があり、必ずしもネットワークそのものが原因とは限らないため、手元で再現できないボトルネックの調査は非常に困難です。\n\n本セッションでは、バックエンドで広く使われている「分散トレーシング（Distributed Tracing）」の概要と、それをAndroidアプリでどのように活用できるかを解説します。また、pixivアプリが世界中の多様な環境のユーザーから愛用される中で、高品質を維持するために、アプリ内の処理とシステム処理の因果関係を明らかにし、パフォーマンスの問題を特定しやすくする手法や、モニタリングの工夫についても紹介します。\n\nさらに、Firebase Performance や Systrace との違いを踏まえながら、OpenTelemetry を使ったトレーシングの設計・運用、モバイル向けにカスタマイズした SDK の実装例、そして実際の改善事例を交えて、「読み込みが遅い」の正体をつかむための技術と仕組みをわかりやすくお伝えします。\n\n想定目次\n\n- なぜ従来の手法ではパフォーマンスの原因を特定が難しいのか\n- 分散トレーシングとは？\n- Trace / Span / Context Propagation の基本概念\n- OpenTelemetry とそのエコシステム\n- Firebase Performance, Systrace との比較\n- Androidアプリ向け分散トレーシングの設計と導入\n- 測定単位の粒度\n- モバイル向け軽量SDKの設計と実装例\n- データ収集とサンプリング\n- 可視化と運用\n- Grafana等を用いた観測方法\n- アラート設計のベストプラクティス\n- 課題解決フローと導入効果\n- パフォーマンス問題解決フローの実例：観測→パフォーマンス指標の遅延→調査→改善→観測\n- 考察と展望\n- 導入前後での開発プロセスの変化\n- 分散トレーシングの持つ将来的な可能性（AIと連携したモニタリングについてなど）",
+        "en": "In Android apps, sluggish startups and janky scrolling directly lead to user churn and lower conversion rates. However, as projects grow in complexity, it becomes difficult with common tools—such as Firebase Performance Monitoring—to pinpoint why performance metrics are dropping and where the actual bottlenecks lie.\n\nFor example, if the time to first frame is slow, you might assume delays in data-layer execution or image decoding are to blame, but in reality the root cause can reside in asynchronous operations outside the app—such as TCP connection establishment or DNS resolution through a CDN. Moreover, I/O contention can also trigger performance issues, so investigating bottlenecks that cannot be reproduced locally is extremely challenging.\n\nIn this session, we’ll cover the fundamentals of distributed tracing—widely used on the backend—and explain how to leverage it in Android apps. We’ll introduce techniques and monitoring strategies that clarify causal relationships between in-app processes and system-level operations, helping you identify performance issues more easily while maintaining high quality in the Pixiv app, which is beloved by users worldwide in diverse environments.\n\nFurthermore, we’ll discuss the design and operation of tracing with OpenTelemetry, highlight differences from Firebase Performance and Systrace, present examples of a mobile-customized SDK implementation, and share real-world case studies of performance improvements. By the end, you’ll understand the technologies and mechanisms needed to uncover what “slow loading” really means.\n\nProposed Session Outline\n\n- Why traditional methods struggle to pinpoint performance issues\n- What is distributed tracing?\n- Core concepts: trace, span, and context propagation\n- OpenTelemetry and its ecosystem\n- Comparison with Firebase Performance and Systrace\n- Designing and introducing distributed tracing for Android apps\n- Granularity of measurement units\n- Designing and implementing a lightweight mobile SDK\n- Data collection and sampling\n- Visualization and operations\n- Observability with tools like Grafana\n- Best practices for alert design\n- Problem-solving flow and results\n- Case study: observability→performance metric degradation→investigation→improvement→re-observability\n- Reflections and future outlook\n- Changes in the development process before and after implementation\n- Future potential of distributed tracing (including AI-driven monitoring, etc.)\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-12T12:20:00+09:00",
+      "endsAt": "2025-09-12T13:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "ee200f6c-92ce-48c1-b2cd-19cceee38971"
+      ],
+      "roomId": 64799,
+      "targetAudience": "■Androidエンジニア\r\n- Android アプリのObservabilityに興味がある方\r\n- Android アプリのパフォーマンス改善全般に興味のある方\r\n- Android アプリのパフォーマンス問題の原因特定が難しいと感じている方\r\n- Firebase Performance Monitoring に限界を感じている方\r\n\r\n■プロダクトマネージャー・チームリーダー\r\n- アプリの現状のパフォーマンスを把握したい方\r\n- アプリ品質を向上させたい方\r\n\r\n■QAエンジニア\r\n- アプリのSLO/SLA/SLIなどパフォーマンス指標のモニタリングに携わる方",
+      "i18nTargetAudience": {
+        "ja": "■Androidエンジニア\n- Android アプリのObservabilityに興味がある方\n- Android アプリのパフォーマンス改善全般に興味のある方\n- Android アプリのパフォーマンス問題の原因特定が難しいと感じている方\n- Firebase Performance Monitoring に限界を感じている方\n\n■プロダクトマネージャー・チームリーダー\n- アプリの現状のパフォーマンスを把握したい方\n- アプリ品質を向上させたい方\n\n■QAエンジニア\n- アプリのSLO/SLA/SLIなどパフォーマンス指標のモニタリングに携わる方",
+        "en": "■Android Engineers\n- Those interested in observability of Android apps\n- Those interested in overall performance improvement of Android apps\n- Those who find it difficult to identify the root causes of Android app performance issues\n- Those who feel limited by Firebase Performance Monitoring\n\n■Product Managers / Team Leaders\n- Those who want to understand their app’s current performance status\n- Those who want to enhance app quality\n\n■QA Engineers\n- Those involved in monitoring performance indicators such as SLO/SLA/SLI for apps"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361165,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "923086",
+      "title": {
+        "ja": "ネットワーク障害を乗り越える：オフラインファーストな Flutter アプリの構築",
+        "en": "Surviving Network Failures: Building Resilient Offline-First Flutter Apps"
+      },
+      "description": "What happens when your app loses internet, does it gracefully adapt, or does it leave users frustrated? In a world where connectivity is unpredictable, building offline-first apps isn’t just a feature; it’s a necessity.\r\n\r\nIn this talk, we’ll explore battle-tested strategies to keep your Flutter app running smoothly, even in airplane mode. You’ll learn:\r\n\r\nCaching Like a Pro – Choosing between SQLite, Hive, Isar, or ObjectBox for local data storage.\r\nSyncing Without Breaking Things – Ensuring data consistency with background sync techniques.\r\nHandling Conflicts Gracefully – Avoiding data loss when multiple devices update the same record.\r\nBackground Tasks \u0026 Work Managers – Keeping data fresh even when the app isn’t open.\r\n\r\nBy the end of this session, you\u0027ll walk away with practical solutions to handle network failures, data synchronization, and seamless user experiences, whether your app is used in the subway, remote villages, or just a bad Wi-Fi zone. ",
+      "i18nDesc": {
+        "ja": "あなたのアプリがインターネット接続を失ったとき、スムーズに動作を続けられますか？それともユーザーを困らせるだけでしょうか？接続が不安定な現代において、オフラインファーストのアプリ設計はもはや「オプション」ではなく「必須」と言えます。\n本セッションでは、飛行機モード中でも Flutter アプリを安定稼働させる、実戦での信頼性が高い戦略を探ります。以下のようなノウハウを共有します：\nキャッシュ戦略を徹底活用：SQLite、Hive、Isar、ObjectBoxなどから最適なローカル保存方式の選び方 \n\n同期を壊さず賢く実行：バックグラウンド同期技術でデータの一貫性を確保する設計 \n\n競合状態へのスムーズな対応：複数デバイスから同じレコードが更新された際にデータ損失を防ぐ方法 \n\nバックグラウンドタスク＆ワークマネージャー：アプリが閉じていてもデータを最新に保つ仕組み\n\nセッション後には、地下鉄や通信が不安定な地域、あるいは不安定なWi‑Fi環境下でも快適なユーザー体験を提供できる、ネットワーク接続が途切れた時の実用的な対応策・データ同期手法・シームレスなUI設計の知見を得られます。\n\n（DroidKaigi実行委員会による翻訳）",
+        "en": "What happens when your app loses internet, does it gracefully adapt, or does it leave users frustrated? In a world where connectivity is unpredictable, building offline-first apps isn’t just a feature; it’s a necessity.\n\nIn this talk, we’ll explore battle-tested strategies to keep your Flutter app running smoothly, even in airplane mode. You’ll learn:\n\nCaching Like a Pro – Choosing between SQLite, Hive, Isar, or ObjectBox for local data storage.\nSyncing Without Breaking Things – Ensuring data consistency with background sync techniques.\nHandling Conflicts Gracefully – Avoiding data loss when multiple devices update the same record.\nBackground Tasks \u0026 Work Managers – Keeping data fresh even when the app isn’t open.\n\nBy the end of this session, you\u0027ll walk away with practical solutions to handle network failures, data synchronization, and seamless user experiences, whether your app is used in the subway, remote villages, or just a bad Wi-Fi zone."
+      },
+      "startsAt": "2025-09-12T17:20:00+09:00",
+      "endsAt": "2025-09-12T18:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "bb418f1f-5970-4716-bc83-13359f40b4c1"
+      ],
+      "roomId": 64800,
+      "targetAudience": "All mobile developers who want to build apps that sustain network failures.",
+      "i18nTargetAudience": {
+        "ja": "ネットワーク障害に強いアプリを構築したい モバイル開発者全般",
+        "en": "All mobile developers who want to build apps that sustain network failures."
+      },
+      "language": "ENGLISH",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361171,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": true,
+        "en": false
+      }
+    },
+    {
+      "id": "944126",
+      "title": {
+        "ja": "Gemini エージェントで Android Studio 開発を高速化",
+        "en": "Develop faster with Gemini Agents in Android Studio"
+      },
+      "description": "At DroidKaigi 2024, we spoke about how Gemini in Android Studio helps accelerate almost all aspects of your development workflow. Now, with agents built around Gemini, you can tackle even more complex multi-file changes that make it easier to design your UI, upgrade dependencies, fix bugs, write end-to-end tests, and more. Join us to see how the next evolution of Gemini in Android Studio can help you push to production more quickly and with higher quality.",
+      "i18nDesc": {
+        "ja": "DroidKaigi 2024 では、Android Studio における Gemini が開発ワークフローのほぼすべての側面を加速する方法についてお話ししました。そして今日、Gemini をベースとしたエージェントが登場し、より複雑なマルチファイルの変更にも対応可能です。これにより、UI 設計、依存関係のアップグレード、バグ修正、エンドツーエンドテストの作成などがより簡単になります。次世代の Gemini を搭載した Android Studio によって、より迅速かつ高品質に本番リリースへと進む方法を一緒に見ていきましょう。\n\n（DroidKaigi実行委員会による翻訳）",
+        "en": "At DroidKaigi 2024, we spoke about how Gemini in Android Studio helps accelerate almost all aspects of your development workflow. Now, with agents built around Gemini, you can tackle even more complex multi-file changes that make it easier to design your UI, upgrade dependencies, fix bugs, write end-to-end tests, and more. Join us to see how the next evolution of Gemini in Android Studio can help you push to production more quickly and with higher quality."
+      },
+      "startsAt": "2025-09-12T10:20:00+09:00",
+      "endsAt": "2025-09-12T11:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "532dc16d-b69d-4f68-aa49-fe9878b0b52f",
+        "878813ad-5687-4a2b-8af4-be13da25eebd"
+      ],
+      "roomId": 64802,
+      "targetAudience": "Beginner to Intermediate Android Developers who use Android Studio.",
+      "i18nTargetAudience": {
+        "ja": "Android Studio を使用する、初級から中級の Android 開発者",
+        "en": "Beginner to Intermediate Android Developers who use Android Studio."
+      },
+      "language": "ENGLISH",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361170,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": true,
+        "en": false
+      }
+    },
+    {
+      "id": "946512",
+      "title": {
+        "ja": "Android 16 × Jetpack Composeで縦書きテキストエディタを作ろう",
+        "en": "Let’s Build an Editor for Vertical Text with Android 16 and Jetpack Compose"
+      },
+      "description": "Android 16でPaintに追加されるVERTICAL_TEXT_FLAGにより、ついに標準で縦書きテキストの描画が可能になります。\r\n本セッションではその新機能とJetpack Composeを組み合わせた簡単な縦書きテキストエディタの実装方法を具体的なコードを交えて紹介します。\r\n\r\nAndroidで縦書きを簡単に使うにはWebViewが必要でした。一方iOSでは以前より縦書きのテキスト描画がサポートされていたため、縦書きのできるテキストエディタアプリの数はAndroidとiOSで天と地ほどの差がある現状です。\r\n日本語文化の重要なピースである縦書きをAndroidにも普及させるべく、本セッションにより誰もが「Androidで縦書きエディタを作れる」ようになることを目指します。\r\n\r\n本セッションではAndroid 16の縦書きのテキスト描画APIのことだけではなく、Jetpack Composeで独自のテキストエディタを作る方法も説明します。\r\nまたJetpack Composeにはテキストの表示からIMEによるテキスト入力を分離して抽象的に扱うことのできる先進的な設計が存在しており、その先進性についてAndroid従来のView含めた他のプラットフォームの事情と比較して解説します。\r\n\r\n#発表のアウトライン\r\n## 縦書きテキスト\r\n・PaintへのVERTICAL_TEXT_FLAGの追加\r\n・縦書きテキストの描画\r\n## Jetpack Composeのテキスト入力とテキスト描画\r\n・PlatformTextInputModifierNode とは\r\n・AndroidのInputConnectionとの関係について\r\n・androidx.compose.text.input からの変遷\r\n## Jetpack Composeと他プラットフォームのテキスト入力周りのAPI設計\r\n・iOS, macOS, Windowsとの比較\r\n## 具体的な縦書きエディタの実装コード",
+      "i18nDesc": {
+        "ja": "Android 16でPaintに追加されるVERTICAL_TEXT_FLAGにより、ついに標準で縦書きテキストの描画が可能になります。\n本セッションではその新機能とJetpack Composeを組み合わせた簡単な縦書きテキストエディタの実装方法を具体的なコードを交えて紹介します。\n\nAndroidで縦書きを簡単に使うにはWebViewが必要でした。一方iOSでは以前より縦書きのテキスト描画がサポートされていたため、縦書きのできるテキストエディタアプリの数はAndroidとiOSで天と地ほどの差がある現状です。\n日本語文化の重要なピースである縦書きをAndroidにも普及させるべく、本セッションにより誰もが「Androidで縦書きエディタを作れる」ようになることを目指します。\n\n本セッションではAndroid 16の縦書きのテキスト描画APIのことだけではなく、Jetpack Composeで独自のテキストエディタを作る方法も説明します。\nまたJetpack Composeにはテキストの表示からIMEによるテキスト入力を分離して抽象的に扱うことのできる先進的な設計が存在しており、その先進性についてAndroid従来のView含めた他のプラットフォームの事情と比較して解説します。\n\n#発表のアウトライン\n## 縦書きテキスト\n・PaintへのVERTICAL_TEXT_FLAGの追加\n・縦書きテキストの描画\n## Jetpack Composeのテキスト入力とテキスト描画\n・PlatformTextInputModifierNode とは\n・AndroidのInputConnectionとの関係について\n・androidx.compose.text.input からの変遷\n## Jetpack Composeと他プラットフォームのテキスト入力周りのAPI設計\n・iOS, macOS, Windowsとの比較\n## 具体的な縦書きエディタの実装コード",
+        "en": "With the new VERTICAL_TEXT_FLAG added to Paint in Android 16, Android finally supports vertical text rendering natively.\nThis session shows, with concrete code examples, how to combine that new feature with Jetpack Compose to build a simple vertical-text editor.\n\nUntil now, anyone wanting easy vertical writing on Android had to resort to a WebView. By contrast, iOS has long supported vertical text, so the number of vertical-writing editors on iOS and Android differs dramatically.\nTo help spread this essential aspect of Japanese typography on Android, this talk aims to make anyone be able to build a vertical-text editor on Android.\n\nThe session covers not only the new vertical-text API in Android 16 but also how to craft a custom text editor in Jetpack Compose. Jetpack Compose separates text display from IME input through an advanced, abstracted design. We’ll explore that forward-looking architecture and compare it with the classic Android View system and other platforms.\n\n# Presentation Outline\n## Vertical Text\n- Addition of VERTICAL_TEXT_FLAG to Paint\n- Rendering vertical text\n## Jetpack Compose: Text Input \u0026 Rendering\n- What is PlatformTextInputModifierNode?\n- Relationship to Android’s InputConnection\n- Evolution since androidx.compose.text.input\n## API Design for Text Input: Compose vs. Other Platforms\n- Comparisons with iOS, macOS, and Windows\n## Complete Implementation: Building a Vertical-Text Editor\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-12T11:20:00+09:00",
+      "endsAt": "2025-09-12T12:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "63a3dc07-8891-4cf2-b74c-15c6f626f7f3"
+      ],
+      "roomId": 64799,
+      "targetAudience": "Androidアプリ開発の基本的な知識のある方を対象にします。\r\n特にAndroidで縦書きエディタを作りたい方に届けたいです。縦書きに興味のある方、Jetpack Composeでのテキストエディタ開発に興味のある方にもおすすめです。",
+      "i18nTargetAudience": {
+        "ja": "Androidアプリ開発の基本的な知識のある方を対象にします。\n特にAndroidで縦書きエディタを作りたい方に届けたいです。縦書きに興味のある方、Jetpack Composeでのテキストエディタ開発に興味のある方にもおすすめです。",
+        "en": "This session targets developers with basic Android-app knowledge, especially those eager to create a vertical-text editor on Android. Anyone interested in vertical writing or text-editor development with Jetpack Compose will also benefit."
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361163,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "944430",
+      "title": {
+        "ja": "厄介な依存関係：サードパーティライブラリのバグを乗り切り修正する方法",
+        "en": "Nasty Dependencies: Surviving and fixing bugs in 3rd-party libraries"
+      },
+      "description": "As developers, we are responsible for bugs in our apps, even when they are caused by third-party dependencies.\r\n\r\nIn this session, I will give an overview of different ways to handle this situation, including:\r\n- Debugging, logging, or fixing issues using advanced Gradle techniques;\r\n- Forking libraries and using them in your project via Git submodules, Nexus repositories, or direct artifacts;\r\n- Upstreaming your changes to the original library repository;\r\n- Possible approaches for working with closed-source libraries.\r\n\r\nThis session will act more like a guidebook than a deep technical dive, offering practical options developers can choose from depending on their situation.",
+      "i18nDesc": {
+        "ja": "たとえサードパーティの依存関係が原因であっても、アプリで発生するバグは開発する私たちの責任です。\n\n本セッションでは、この状況に対処するさまざまな方法を概観します。具体的には次のようなトピックを扱います：\n\n- 高度なGradleテクニックを用いたデバッグ、ログ取得、または問題の修正\n- ライブラリをフォークし、GitサブモジュールやNexusリポジトリ、または直接生成したアーティファクトを通してプロジェクトに組み込む方法\n- 変更を元のライブラリリポジトリへアップストリームする手順\n- クローズドソースライブラリと付き合う際のアプローチ\n\nこのセッションは深い技術解説というよりもガイドブックとして機能し、状況に応じて選択できる実践的な選択肢を開発者に提示します。\n\n（DroidKaigi実行委員会による翻訳）",
+        "en": "As developers, we are responsible for bugs in our apps, even when they are caused by third-party dependencies.\n\nIn this session, I will give an overview of different ways to handle this situation, including:\n- Debugging, logging, or fixing issues using advanced Gradle techniques;\n- Forking libraries and using them in your project via Git submodules, Nexus repositories, or direct artifacts;\n- Upstreaming your changes to the original library repository;\n- Possible approaches for working with closed-source libraries.\n\nThis session will act more like a guidebook than a deep technical dive, offering practical options developers can choose from depending on their situation."
+      },
+      "startsAt": "2025-09-12T16:20:00+09:00",
+      "endsAt": "2025-09-12T17:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "422dabe0-25c9-4217-b08c-77d06630853e"
+      ],
+      "roomId": 64801,
+      "targetAudience": "Android developers who are using third-party libraries (primarily open-source ones) and experiencing issues with them.\r\n\r\nMinimal experience with Git, GitHub and Gradle is expected.",
+      "i18nTargetAudience": {
+        "ja": "サードパーティ（主にオープンソース）ライブラリを利用していて問題に直面しているAndroid開発者。\n\nGit、GitHub、Gradleの基本的な経験があることを前提とします。",
+        "en": "Android developers who are using third-party libraries (primarily open-source ones) and experiencing issues with them.\n\nMinimal experience with Git, GitHub and Gradle is expected."
+      },
+      "language": "ENGLISH",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361170,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": true,
+        "en": false
+      }
+    },
+    {
+      "id": "939784",
+      "title": {
+        "ja": "Compose Multiplatform × AI で作る、次世代アプリ開発支援ツールの設計と実装",
+        "en": "Design and Implementation of a Next-Generation App-Development Assistant Built with Compose Multiplatform and AI"
+      },
+      "description": "近年、コード補完にとどまらず、LLM を活用してアプリケーション全体を支援・構築する取り組みが注目されています。本セッションでは、私が開発中の Compose Multiplatform ベースのデスクトップアプリ「ComposeFlow」の開発を通じて得られた、以下のような知見を共有します。\r\n\r\nComposeFlow は、モバイルアプリ開発の敷居を下げることを目指した AI ファーストなビジュアル開発環境です。ユーザーが自然言語で指示を出すと、LLM がそれを読み取り、アプリ構成の変更操作（例：UIコンポーネントの追加や削除、プロジェクト設定の変更など）を行います。このために、エディタ内のあらゆる操作を「tool」として定義し、LLM が直接呼び出せる仕組みを備えています。\r\n\r\n本セッションでは、こうした AI に操作されることを前提とした開発環境を構築するうえでの技術的チャレンジやアーキテクチャ設計について掘り下げます。\r\n\r\n具体的には：\r\n\r\n- Android/iOS/Web アプリを対象としたビジュアルエディタを Compose Multiplatform で構築する方法\r\n\r\n- アプリの構成情報を中間表現（YAML）として扱い、AI による生成や編集を可能にする仕組み\r\n\r\n- GUI の各操作を API として定義し、LLM がそれらを tool として呼び出せる構造\r\n\r\n- Cline や Cursor のようなコード補完ではなく、GUI を直接 AI に操作させるアプローチ\r\n\r\n- Agent にどのようにツール群を公開するか、信頼性の担保や失敗時の再試行戦略などの運用知見\r\n\r\nComposeFlow 自体は現在クローズドソースですが、将来的にはオープンソースとして公開を予定しています。本セッションはプロダクトの紹介ではなく、「AI × GUI × Compose Multiplatform × Agent API 設計」という文脈での技術知見を共有することを目的としています。",
+      "i18nDesc": {
+        "ja": "近年、コード補完にとどまらず、LLM を活用してアプリケーション全体を支援・構築する取り組みが注目されています。本セッションでは、私が開発中の Compose Multiplatform ベースのデスクトップアプリ「ComposeFlow」の開発を通じて得られた、以下のような知見を共有します。\n\nComposeFlow は、モバイルアプリ開発の敷居を下げることを目指した AI ファーストなビジュアル開発環境です。ユーザーが自然言語で指示を出すと、LLM がそれを読み取り、アプリ構成の変更操作（例：UIコンポーネントの追加や削除、プロジェクト設定の変更など）を行います。このために、エディタ内のあらゆる操作を「tool」として定義し、LLM が直接呼び出せる仕組みを備えています。\n\n本セッションでは、こうした AI に操作されることを前提とした開発環境を構築するうえでの技術的チャレンジやアーキテクチャ設計について掘り下げます。\n\n具体的には：\n\n- Android/iOS/Web アプリを対象としたビジュアルエディタを Compose Multiplatform で構築する方法\n\n- アプリの構成情報を中間表現（YAML）として扱い、AI による生成や編集を可能にする仕組み\n\n- GUI の各操作を API として定義し、LLM がそれらを tool として呼び出せる構造\n\n- Cline や Cursor のようなコード補完ではなく、GUI を直接 AI に操作させるアプローチ\n\n- Agent にどのようにツール群を公開するか、信頼性の担保や失敗時の再試行戦略などの運用知見\n\nComposeFlow 自体は現在クローズドソースですが、将来的にはオープンソースとして公開を予定しています。本セッションはプロダクトの紹介ではなく、「AI × GUI × Compose Multiplatform × Agent API 設計」という文脈での技術知見を共有することを目的としています。",
+        "en": "In recent years, efforts that leverage LLMs to support and construct entire applications—going beyond mere code completion—have drawn significant attention. This session shares insights gained from developing “ComposeFlow,” a desktop app built on Compose Multiplatform.\n\nComposeFlow is an AI-first visual development environment aimed at lowering the barrier to mobile app development. When users issue instructions in natural language, an LLM interprets them and performs app structure modifications (e.g., adding and removing UI components, changing project settings). To enable this, every editor action is defined as a “tool” that the LLM can call directly.\n\nThis session dives into the technical challenges and architectural design of building a development environment intended to be operated by AI.\n\nSpecifically:\n\n- Building a visual editor for Android/iOS/Web apps with Compose Multiplatform\n\n- Treating app configuration as an intermediate representation (YAML) to enable AI-driven generation and editing\n\n- Defining each GUI action as an API so the LLM can invoke it as a tool\n\n- Allowing the AI to manipulate the GUI directly, instead of relying on code-completion tools like Cline or Cursor\n\n- Exposing toolsets to an agent, ensuring reliability, and implementing retry strategies after failures\n\nComposeFlow is currently closed-source, but is planned to be open-source in the future. This session is not a product promotion; its goal is to share technical knowledge in the context of “AI × GUI × Compose Multiplatform × Agent API design.”\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-12T10:20:00+09:00",
+      "endsAt": "2025-09-12T11:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "e3267cf5-b1a7-4ce7-a4b3-223925f21316"
+      ],
+      "roomId": 64800,
+      "targetAudience": "- Compose Multiplatform でどんなことができるか興味がある人\r\n- 既存のアプリケーションを LLM 経由で操作させることに興味がある人\r\n- LLMを使用したアプリケーションの例に興味がある人",
+      "i18nTargetAudience": {
+        "ja": "- Compose Multiplatform でどんなことができるか興味がある人\n- 既存のアプリケーションを LLM 経由で操作させることに興味がある人\n- LLMを使用したアプリケーションの例に興味がある人",
+        "en": "- Those interested in what Compose Multiplatform can do\n- Anyone curious about operating existing applications via LLMs\n- People looking for practical examples of LLM-based applications"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 366660,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "946620",
+      "title": {
+        "ja": "衛星元年 スマホ圏外からLEO衛星🛰で安否情報を届けるAndroid DTC (Direct to Cell)完全攻略",
+        "en": "Year One for Satellites: Fully Mastering Android DTC (Direct to Cell) to Deliver Safety Updates from Dead Zones via LEO Satellites🛰"
+      },
+      "description": "2025年4月、日本国内でAndroid端末が低軌道（LEO）通信衛星と直接つながるDTC（Direct to Cell / D2C）が商用サービス化されました。\r\nDTCで先行していたiOSの緊急通報とは利用衛星もサービス性質も大きく異なります。\r\nAndroid 15にはDTCの初期サポートが追加され、アプリ開発者が通信衛星への接続状態を取得できます。\r\n\r\n「スマホ圏外が無くなる」というインパクトは大きく、山や海のレジャーから減災まで幅広い用途が期待されています。\r\n多くの方はまず実用性に関心があるのではないでしょうか。そして、新たな通信手段をアプリにどう活用できるかという関心も高いでしょう。\r\n\r\n本セッションは、スマホと人工衛星の直接通信（DTC）によってアプリの限界を広げることに関心がある方を対象とします。\r\n発表者がスマホ圏外から家族や友人へ安全のための位置情報を共有するサービスを開発する中で得た実フィールドでの実用性、現状のDTCが持つ制約の中でそのポテンシャルを最大限に引き出すアプリ開発者視点での取り組み結果、特に通信を確立してスマホ圏外での活動の安全へ役立てるための工夫の数々を紹介します。\r\n\r\n\r\n下記は紹介予定トピックの一部です。\r\n\r\n登山用の圏外安否情報共有ツール、仮称「anzenmap」の試作・開発を通じて30時間程度の検証登山を実施しました。\r\n現状日本国内唯一のDTC対応サービスであるau回線は、衛星の電波を適切に掴んでいる状態ならあっさりとSMS送信に成功します。\r\nアンテナピクトの🛰マークを見なければ衛星接続中と気付かないほどスムーズです。\r\nしかし、まだ安定した通信手段ではありません。秒速10kmで移動する基地局という特殊性のため、周囲を建物や山々に囲まれた環境で通信可能状態を数分間続けて保てるタイミングは少ないです。\r\nDTC対応衛星はまだ最終的な想定数の10%程度であり、そもそも視界に衛星が存在しないことも多いです。\r\n\r\n「現在通信できそうか、数分間待たなければ通信できないのか」という正確な判断が実用性を大きく左右します。\r\nAndroid 15では「衛星に接続されているか否かを取得できる」ようになりましたが、実地検証の結果この情報にあまり頼れないこともわかりました。\r\n\r\nanzenmapは利用者の位置情報を定期的に所定フォーマットで自動SMS送信します。このため到達性は重要な要件です。バッテリー効率を重視しつつ現時点のアプリ開発者が出来る範囲で最大限に衛星の電波を掴むために、肉眼では見えない通信衛星と利用者との位置関係を適切に把握できるようにしました。\r\n\r\n- 自身の視界内に衛星があるか否かを衛星軌道計算によってオフラインで判定する\r\n- 自身の周囲の地形によって衛星との通信が失敗しうることを国土地理院の標高タイルを用いて判定する\r\n\r\nこれらを組み合わせて適切な通信スケジューリングを実現し、あわせて通信経路確保のためにSMSゲートウェイを構築して山梨県・栃木県の山中で検証した結果、端末のバッテリー消費を含めて十分に実用的といえる水準まで到達しました。\r\n\r\n最後に、DTCがアプリ開発にもたらす変化の展望を簡単に共有します。\r\n- 「通信が通常よりも安定しないかもしれないから少ないデータで出来る範囲のことをやろう」という判断\r\n- 「スマホ圏外だけど今なら衛星につながっているかもしれないからデータアクセスで最重要なものをやろう」という判断\r\n過渡期にはどちらもあり得ます。\r\n\r\n皆様のアプリが衛星直接通信と向き合う一助になると幸いです。",
+      "i18nDesc": {
+        "ja": "2025年4月、日本国内でAndroid端末が低軌道（LEO）通信衛星と直接つながるDTC（Direct to Cell / D2C）が商用サービス化されました。\nDTCで先行していたiOSの緊急通報とは利用衛星もサービス性質も大きく異なります。\nAndroid 15にはDTCの初期サポートが追加され、アプリ開発者が通信衛星への接続状態を取得できます。\n\n「スマホ圏外が無くなる」というインパクトは大きく、山や海のレジャーから減災まで幅広い用途が期待されています。\n多くの方はまず実用性に関心があるのではないでしょうか。そして、新たな通信手段をアプリにどう活用できるかという関心も高いでしょう。\n\n本セッションは、スマホと人工衛星の直接通信（DTC）によってアプリの限界を広げることに関心がある方を対象とします。\n発表者がスマホ圏外から家族や友人へ安全のための位置情報を共有するサービスを開発する中で得た実フィールドでの実用性、現状のDTCが持つ制約の中でそのポテンシャルを最大限に引き出すアプリ開発者視点での取り組み結果、特に通信を確立してスマホ圏外での活動の安全へ役立てるための工夫の数々を紹介します。\n\n\n下記は紹介予定トピックの一部です。\n\n登山用の圏外安否情報共有ツール、仮称「anzenmap」の試作・開発を通じて30時間程度の検証登山を実施しました。\n現状日本国内唯一のDTC対応サービスであるau回線は、衛星の電波を適切に掴んでいる状態ならあっさりとSMS送信に成功します。\nアンテナピクトの🛰マークを見なければ衛星接続中と気付かないほどスムーズです。\nしかし、まだ安定した通信手段ではありません。秒速10kmで移動する基地局という特殊性のため、周囲を建物や山々に囲まれた環境で通信可能状態を数分間続けて保てるタイミングは少ないです。\nDTC対応衛星はまだ最終的な想定数の10%程度であり、そもそも視界に衛星が存在しないことも多いです。\n\n「現在通信できそうか、数分間待たなければ通信できないのか」という正確な判断が実用性を大きく左右します。\nAndroid 15では「衛星に接続されているか否かを取得できる」ようになりましたが、実地検証の結果この情報にあまり頼れないこともわかりました。\n\nanzenmapは利用者の位置情報を定期的に所定フォーマットで自動SMS送信します。このため到達性は重要な要件です。バッテリー効率を重視しつつ現時点のアプリ開発者が出来る範囲で最大限に衛星の電波を掴むために、肉眼では見えない通信衛星と利用者との位置関係を適切に把握できるようにしました。\n\n- 自身の視界内に衛星があるか否かを衛星軌道計算によってオフラインで判定する\n- 自身の周囲の地形によって衛星との通信が失敗しうることを国土地理院の標高タイルを用いて判定する\n\nこれらを組み合わせて適切な通信スケジューリングを実現し、あわせて通信経路確保のためにSMSゲートウェイを構築して山梨県・栃木県の山中で検証した結果、端末のバッテリー消費を含めて十分に実用的といえる水準まで到達しました。\n\n最後に、DTCがアプリ開発にもたらす変化の展望を簡単に共有します。\n- 「通信が通常よりも安定しないかもしれないから少ないデータで出来る範囲のことをやろう」という判断\n- 「スマホ圏外だけど今なら衛星につながっているかもしれないからデータアクセスで最重要なものをやろう」という判断\n過渡期にはどちらもあり得ます。\n\n皆様のアプリが衛星直接通信と向き合う一助になると幸いです。",
+        "en": "In April 2025, the commercial DTC (Direct to Cell / D2C) service enabling Android devices in Japan to connect directly to low-Earth-orbit (LEO) communication satellites went live.\nThe satellites used and the nature of the service differ substantially from the emergency SOS feature that debuted earlier on iOS.\nAndroid 15 introduces initial DTC support, allowing app developers to query the handset’s connection state to the communications satellite.\n\nThe promise of “no more out of range” is huge, opening possibilities from outdoor leisure in the mountains or at sea to disaster-mitigation scenarios.\nMost people will first wonder whether it really works, and developers will naturally ask how this new communications channel can be woven into their apps.\n\nThis session targets anyone interested in pushing app boundaries through direct handset-to-satellite communication.\nDrawing on the speaker’s development of an off-grid safety-location-sharing service for family and friends, we will report field-test results, highlight the current constraints of DTC, and share developer-centric techniques for squeezing the most out of it—especially the tricks for establishing a link and turning it into real safety value when you are beyond cellular coverage.\n\nThese are some of the topics we will cover:\n\nWe prototyped and field-tested for roughly 30 hours in the mountains a safety-message tool tentatively named “anzenmap” designed for climbers outside coverage.\nau, Japan’s sole DTC-capable network today, can send an SMS instantly as long as the handset is holding the satellite signal; the experience is so seamless that without the 🛰 icon in the status bar you might not notice you are on a satellite link.\nYet DTC is not a stable pipe: the “base station” is flying past at 10 km/s, so in valleys or built-up areas there are only a few windows of a couple of minutes during which the link can stay up.\nOnly about 10 % of the planned DTC satellites are in orbit so far, meaning that quite often no satellite is in view at all.\n\nBeing able to tell accurately whether you can transmit right now—or need to wait a few minutes—makes or breaks usability.\nAndroid 15 exposes an API for “is the handset connected to a satellite?”, but field tests revealed that this flag alone is often misleading.\n\nanzenmap periodically sends the user’s location as an SMS in a predefined format, so delivery reliability is a critical requirement.\nWhile keeping battery usage low, we maximize the chances of latching onto the satellite signal by letting the user—and the app—understand the geometry between the invisible satellite and the handset.\n\n- Compute satellite orbits offline to decide whether a satellite is currently within line-of-sight.\n- Use Geospatial Information Authority of Japan elevation tiles to judge whether surrounding terrain may block the link.\n\nBy combining these techniques we built an appropriate transmission scheduler and, together with a custom SMS gateway, tested the system deep in the mountains of Yamanashi and Tochigi prefectures. We reached a level of practicality—battery consumption included—that we can confidently call usable.\n\nFinally, we will sketch how DTC may reshape app design:\n- Opting to do as much as possible with minimal data because the link may be flaky;\n- Conversely, deciding to grab the single most important data when the handset shows a rare satellite connection despite being off-grid.\nDuring the transition both mind-sets will coexist.\n\nI hope this talk helps your apps embrace direct satellite communication.\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-12T14:20:00+09:00",
+      "endsAt": "2025-09-12T15:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "5941685d-2917-43ff-8651-02e9c3f3b0fb"
+      ],
+      "roomId": 64799,
+      "targetAudience": "- スマホと人工衛星の直接通信（DTC）によってアプリの限界を広げることに関心がある方\r\n- Android SDKの利用経験（あると望ましい、なくても内容理解の上では問題ない）\r\n- Pythonコードの読み書き経験（あると望ましい、なくても内容理解の上では問題ない）\r\n- 500km先を10km/sで移動する基地局と通信することにワクワクする方",
+      "i18nTargetAudience": {
+        "ja": "- スマホと人工衛星の直接通信（DTC）によってアプリの限界を広げることに関心がある方\n- Android SDKの利用経験（あると望ましい、なくても内容理解の上では問題ない）\n- Pythonコードの読み書き経験（あると望ましい、なくても内容理解の上では問題ない）\n- 500km先を10km/sで移動する基地局と通信することにワクワクする方",
+        "en": "- Anyone excited about pushing app boundaries through smartphone-to-satellite DTC\n- Experience with the Android SDK (helpful but not essential)\n- Ability to read and write Python code (helpful but not essential)\n- People who get a thrill from talking to a base station 500 km away racing by at 10 km/s"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361163,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "944034",
+      "title": {
+        "ja": "逆向きUIの世界〜AndroidアプリのRTL言語対応〜",
+        "en": "The World of Reverse-Oriented UI—RTL Language Support in Android Apps"
+      },
+      "description": "多言語対応をしていると、いつかはRTL（Right To Left）言語、つまり右から左に書かれる言語への対応が必要になる場面に出会います。私が担当しているAndroidアプリでもその対応が求められました。\r\n\r\nではRTL言語対応って具体的に何をすべきかご存知でしょうか？\r\nAndroidでは、OSやフレームワークによってある程度「自動対応」がされます。しかし、UIの崩れ、画像の反転、レイアウトの意図しない挙動など、エンジニアが「手動対応」しなければいけない場面も存在します。\r\n\r\nこのトークでは次のような観点から、私が調査、実装をしたRTL言語対応の知見を共有します。\r\n\r\n1. そもそもRTL言語対応とはどんなものか\r\n2. OS、フレームワーク側が「自動で」してくれるRTL言語対応\r\n3. エンジニアが「手動で」頑張るRTL言語対応\r\n3.1 レイアウト修正\r\n3.2 画像修正\r\n3.3 その他思わぬ落とし穴\r\n4. 対応状況をどのように確認するか\r\n\r\nこのトークを聞けば、初めてRTL言語対応に取り組む方でも迷わず対応できるはずです。",
+      "i18nDesc": {
+        "ja": "多言語対応をしていると、いつかはRTL（Right To Left）言語、つまり右から左に書かれる言語への対応が必要になる場面に出会います。私が担当しているAndroidアプリでもその対応が求められました。\n\nではRTL言語対応って具体的に何をすべきかご存知でしょうか？\nAndroidでは、OSやフレームワークによってある程度「自動対応」がされます。しかし、UIの崩れ、画像の反転、レイアウトの意図しない挙動など、エンジニアが「手動対応」しなければいけない場面も存在します。\n\nこのトークでは次のような観点から、私が調査、実装をしたRTL言語対応の知見を共有します。\n\n1. そもそもRTL言語対応とはどんなものか\n2. OS、フレームワーク側が「自動で」してくれるRTL言語対応\n3. エンジニアが「手動で」頑張るRTL言語対応\n3.1 レイアウト修正\n3.2 画像修正\n3.3 その他思わぬ落とし穴\n4. 対応状況をどのように確認するか\n\nこのトークを聞けば、初めてRTL言語対応に取り組む方でも迷わず対応できるはずです。",
+        "en": "When you localize an app, sooner or later you will need to support RTL (Right-To-Left) languages—those written from right to left. The Android app I oversee recently faced this requirement.\n\nBut what exactly must be done to enable RTL?\nAndroid’s OS and framework handle part of the job “automatically,” yet engineers still have to intervene manually to fix UI breakage, mirror images, and correct unintended layout behavior.\n\nIn this talk I will share the insights gained during my research and implementation of RTL support from the following perspectives:\n\n1. What RTL language support actually entails\n2. RTL handling that the OS and framework perform “automatically”\n3. RTL handling that engineers must tackle “manually”\n3.1 Layout fixes\n3.2 Image fixes\n3.3 Other unexpected pitfalls\n4. How to verify the support status\n\nAfter attending, even first-timers addressing RTL language support should be able to proceed with confidence.\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-12T14:20:00+09:00",
+      "endsAt": "2025-09-12T15:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "2259b11d-cb9b-47df-a0b5-6c89fe0ce659"
+      ],
+      "roomId": 64801,
+      "targetAudience": "多言語対応に臨む開発者",
+      "i18nTargetAudience": {
+        "ja": "多言語対応に臨む開発者",
+        "en": "Developers tackling multilingual support"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361161,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "946001",
+      "title": {
+        "ja": "ユーザーも開発者も悩ませない TV アプリ開発 - Compose の内部実装から学ぶフォーカス制御",
+        "en": "Worry free TV App development for users and developers - a focus on Compose internal implementation."
+      },
+      "description": "Android TV アプリの UX において重要なのが、リモコン操作による「直感的なフォーカス移動」と「それに伴う適切なスクロール」です。これらは視認性や操作感に直結し、アプリの UX に大きく影響します。従来の Leanback ライブラリはこの点を自動でカバーしていましたが、命令的な UI 描画による状態管理の複雑さや、独自の実装パターンによる学習コストが課題でした。\r\n\r\n2024 年に stable となった Compose for TV の登場により、これらの課題は解決可能となり、宣言的な UI 描画の恩恵を TV アプリでも享受できるようになりました。\r\n\r\n一方で、Compose for TV では Leanback ほど「ユーザーの期待に沿ったフォーカス・スクロール制御」を暗黙的には提供していません。加えて、その仕組みを理解しないまま制御をしようとすると、適切な API を使っても意図通りに動作しないこともあります。このため、直感的な UX を実現するには Compose 内部で作用しているフォーカスやスクロールの仕組みを理解し、適切に制御する必要があります。\r\n\r\nここで特徴的なのは、モバイル向けと同様の Composable を用いて開発できる一方で、その内部では TV 向けの専用ロジックが動作しているという点です。例えば、フォーカス移動に伴う自動スクロールはモバイルと同様に Modifier.verticalScroll を使って実現できますが、LazyColumn の userScrollEnabled パラメーターとは連動されません。さらに、Modifier.verticalScroll はスクロール機能にとどまらず、フォーカス制御の挙動にも副次的ながら重要な影響を与えています。\r\n\r\nこうした Compose for TV 特有の挙動を踏まえつつ、本セッションでは以下の内容を扱います：\r\n・Compose for TV のフォーカス移動やスクロールに関する内部ロジック\r\n・挙動をカスタマイズするために必要な概念や仕組み\r\n・自然な UX を実現するための挙動制御に関する具体的な実装例\r\n\r\nこれにより、開発者が迷うことなく Compose for TV を用いた TV アプリ開発に取り組めるようにし、開発時のデバッグ時間も大幅に削減できる状態を目指します。",
+      "i18nDesc": {
+        "ja": "Android TV アプリの UX において重要なのが、リモコン操作による「直感的なフォーカス移動」と「それに伴う適切なスクロール」です。これらは視認性や操作感に直結し、アプリの UX に大きく影響します。従来の Leanback ライブラリはこの点を自動でカバーしていましたが、命令的な UI 描画による状態管理の複雑さや、独自の実装パターンによる学習コストが課題でした。\n\n2024 年に stable となった Compose for TV の登場により、これらの課題は解決可能となり、宣言的な UI 描画の恩恵を TV アプリでも享受できるようになりました。\n\n一方で、Compose for TV では Leanback ほど「ユーザーの期待に沿ったフォーカス・スクロール制御」を暗黙的には提供していません。加えて、その仕組みを理解しないまま制御をしようとすると、適切な API を使っても意図通りに動作しないこともあります。このため、直感的な UX を実現するには Compose 内部で作用しているフォーカスやスクロールの仕組みを理解し、適切に制御する必要があります。\n\nここで特徴的なのは、モバイル向けと同様の Composable を用いて開発できる一方で、その内部では TV 向けの専用ロジックが動作しているという点です。例えば、フォーカス移動に伴う自動スクロールはモバイルと同様に Modifier.verticalScroll を使って実現できますが、LazyColumn の userScrollEnabled パラメーターとは連動されません。さらに、Modifier.verticalScroll はスクロール機能にとどまらず、フォーカス制御の挙動にも副次的ながら重要な影響を与えています。\n\nこうした Compose for TV 特有の挙動を踏まえつつ、本セッションでは以下の内容を扱います：\n・Compose for TV のフォーカス移動やスクロールに関する内部ロジック\n・挙動をカスタマイズするために必要な概念や仕組み\n・自然な UX を実現するための挙動制御に関する具体的な実装例\n\nこれにより、開発者が迷うことなく Compose for TV を用いた TV アプリ開発に取り組めるようにし、開発時のデバッグ時間も大幅に削減できる状態を目指します。",
+        "en": "While mainly focused on Android TV App UI, this talk also covers remote control “Intuitive focus movement” and “a befitting snappy scrolling”. These have a direct effect on visibility and ease of use and therefore have a great effect on an app’s UI. Up until now, the Leanback library automatically covered these points, but at the cost of the complexity of Imperative UI management style and the learning curve of a more independent design pattern.\n\nSince Compose for TV became stable in 2024 it has become possible for TV apps to resolve these issues as they now too can benefit from the features of Declarative UI.\n\nOn the other hand, Compose for TV is not generally exposing “Focus scroll according to user expectations.” concepts to developers as much as Leanback. In addition, implementing without understanding how that kind of design works (even with a well designed API) can result in an app that doesn\u0027t function as desired. In light of that fact, in order to build truly intuitive designs it’s necessary to deeply understand the focus scroll design used inside compose.\n\nThe distinctive part here is that externally mobile oriented composable code is being used while under the hood TV oriented logic is actually being used to make the TV interface operate. For example, scrolling obeys focus movement and allows Modifier.vertical scroll to be used but LazyColumn’s userScrollEnabled parameter does not function. Modifier.verticalScroll doesn’t just function in scrolling but also has important side effects on the way focus development behaves.\n\nThe characteristic behavior of Compose for TV will be introduced in the following steps: ・Compose for TV’s internal logic for focus movement and scroll\n・Concepts and structure of custom behavior\n・Concrete examples of behavior controls necessary for achieving a natural feeling UI \n\nWith this, developers can make TV Apps using Compose for TV without hesitation and aim for greatly reduced debug time.\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-11T14:20:00+09:00",
+      "endsAt": "2025-09-11T15:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "008463d6-4b97-43b6-94e8-48b7862c1650"
+      ],
+      "roomId": 64799,
+      "targetAudience": "- Jetpack Compose を用いて Mobile アプリを開発した経験があり、Compose for TV との違いを知りたい方\r\n- Jetpack Compose の基礎知識があり、Leanback から Compose for TV への移行を検討している方\r\n- Compose for TV を利用した開発中に、フォーカス制御処理でつまづいている方",
+      "i18nTargetAudience": {
+        "ja": "- Jetpack Compose を用いて Mobile アプリを開発した経験があり、Compose for TV との違いを知りたい方\n- Jetpack Compose の基礎知識があり、Leanback から Compose for TV への移行を検討している方\n- Compose for TV を利用した開発中に、フォーカス制御処理でつまづいている方",
+        "en": "- Developers with experience with Jetpack Compose for mobile and want to know the difference between mobile and Compose for TV.\n- Those with basic knowledge about Jetpack Compose and want to experience transitioning from Leanback to Compose for TV.\n- Those working with Compose for TV who want to learn about Focus control handling."
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361169,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "bd2e2097-bb4d-4780-bd91-ebfb3534a480",
+      "title": {
+        "ja": "特定のテーマで話せるミートアップ",
+        "en": "Themed Meetups"
+      },
+      "description": "様々なテーマごとに集まって、ランチやおやつを食べながら交流しましょう。\nテーマは開催時間ごとに違うものをご用意しています。興味があるテーマを見つけてぜひご参加ください。\n席に限りがありますので、参加を希望される方はお時間になりましたらお早めにお越しください。なお、ランチタイムのミートアップにはお弁当受け取り後にお越しください。\n\n9/11(木) 13:00-14:20：女性、English Speaking、首都圏以外から参加\n9/12(金) 13:00-14:20：Android初学者、一人で開発、子育てと仕事\n9/12(金) 16:20-17:00：AI活用、マネジメント、キャリアプラン",
+      "i18nDesc": {
+        "ja": "様々なテーマごとに集まって、ランチやおやつを食べながら交流しましょう。\nテーマは開催時間ごとに違うものをご用意しています。興味があるテーマを見つけてぜひご参加ください。\n席に限りがありますので、参加を希望される方はお時間になりましたらお早めにお越しください。なお、ランチタイムのミートアップにはお弁当受け取り後にお越しください。\n\n9/11(木) 13:00-14:20：女性、English Speaking、首都圏以外から参加\n9/12(金) 13:00-14:20：Android初学者、一人で開発、子育てと仕事\n9/12(金) 16:20-17:00：AI活用、マネジメント、キャリアプラン",
+        "en": "Let\u0027s gather around various themes and engage in conversations over lunch or snacks. Each session features a different theme, so find one that interests you and join us!\nPlease note that seating is limited. If you wish to participate, kindly arrive promptly at the scheduled time. For lunch-time meetups, please pick up your lunch before joining.\n\nThu, 11 Sep 2025 13:00-14:20 : Women, English Speaking, Participating from outside the Tokyo metropolitan area\nFri, 12 Sep 2025 13:00-14:20 : Android Beginners, Solo Developer, Parenting and Work\nFri, 12 Sep 2025 16:20-17:00 : AI utilization, Management, Career Plans"
+      },
+      "startsAt": "2025-09-12T13:00:00+09:00",
+      "endsAt": "2025-09-12T14:20:00+09:00",
+      "isServiceSession": true,
+      "isPlenumSession": false,
+      "speakers": [],
+      "roomId": 64803,
+      "targetAudience": "TBW",
+      "i18nTargetAudience": {
+        "ja": "TBW",
+        "en": "TBW"
+      },
+      "language": "MIXED",
+      "lengthInMinutes": 80,
+      "sessionCategoryItemId": 361173,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "BEGINNER",
+        "INTERMEDIATE",
+        "ADVANCED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": true,
+        "en": true
+      }
+    },
+    {
+      "id": "946143",
+      "title": {
+        "ja": "Androidベースの2輪車向けシステムの開発課題",
+        "en": "Challenges developing an Android based system for 2-wheel vehicles"
+      },
+      "description": "Developing an Android system for 2-wheel vehicles (such as motorbikes and scooters) presents unique challenges not typical for general Android apps. While Android Automotive OS (AAOS) attempts to bridge the gap between Android and vehicles, 2-wheel vehicles have needs that require going beyond what standard AAOS offers.\r\n\r\nThis session will present a high level look at various requirements, aspects and challenges related to building an Android based ecosystem for 2-wheel vehicles, alongside some additional complications related to developing a portable software architecture that can target multiple vehicle configurations. Areas include:\r\n\r\n- Building a system with a unified user experience\r\n- Non-standard user inputs\r\n- Communication between the vehicle and the app\r\n- Power management\r\n- Legal requirements\r\n- Vehicle and rider safety\r\n- Development and debugging of non-typical hardware\r\n\r\nWhether you\u0027re a developer experienced in developing custom Android systems, someone who loves motorbikes or cars, or just someone looking to broaden their horizons, this talk will bring new insight into the world of 2-wheel software development.",
+      "i18nDesc": {
+        "ja": "バイクやスクーターなどの2輪車向けにAndroidシステムを開発する際には、一般的なAndroidアプリでは想定されない独自の課題が存在します。Android Automotive OS(AAOS)はAndroidと車両を繋いでくれるものの、2輪車には標準的なAAOSを超えるニーズがあります。\n\n本セッションでは、複数の車両構成をターゲットとするポータブルなアーキテクチャを開発する際に生じる独特の複雑性と、2輪車に向けたAndroidベースのエコシステムの構築に関わる要件、観点、課題を詳しく紹介します。\n\n以下の内容を含みます：\n- 統一されたユーザーエクスペリエンスを提供するシステムの構築\n- 特殊なユーザー入力方法\n- 車両とアプリ間の通信\n- 電源管理\n- 法的要件\n- 車両とライダーの安全\n- 特殊なハードウェアの開発とデバッグ\n\nカスタムAndroidシステムの開発経験がある開発者や、バイクや車を愛する人、単に視野を広げたい方まで、このセッションは2輪車ソフトウェア開発の世界に新たな洞察をもたらします。\n\n（DroidKaigi実行委員会による翻訳）",
+        "en": "Developing an Android system for 2-wheel vehicles (such as motorbikes and scooters) presents unique challenges not typical for general Android apps. While Android Automotive OS (AAOS) attempts to bridge the gap between Android and vehicles, 2-wheel vehicles have needs that require going beyond what standard AAOS offers.\n\nThis session will present a high level look at various requirements, aspects and challenges related to building an Android based ecosystem for 2-wheel vehicles, alongside some additional complications related to developing a portable software architecture that can target multiple vehicle configurations. Areas include:\n\n- Building a system with a unified user experience\n- Non-standard user inputs\n- Communication between the vehicle and the app\n- Power management\n- Legal requirements\n- Vehicle and rider safety\n- Development and debugging of non-typical hardware\n\nWhether you\u0027re a developer experienced in developing custom Android systems, someone who loves motorbikes or cars, or just someone looking to broaden their horizons, this talk will bring new insight into the world of 2-wheel software development."
+      },
+      "startsAt": "2025-09-12T16:20:00+09:00",
+      "endsAt": "2025-09-12T17:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "64a854a3-1e09-4aa6-a8a9-2f4b8d94abfe"
+      ],
+      "roomId": 64799,
+      "targetAudience": "Android Engineers, UI/UX designers, and anyone with a love of vehicles.",
+      "i18nTargetAudience": {
+        "ja": "Androidエンジニア、UI/UXデザイナー、および乗り物を愛するすべての人",
+        "en": "Android Engineers, UI/UX designers, and anyone with a love of vehicles."
+      },
+      "language": "ENGLISH",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361163,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": true,
+        "en": false
+      }
+    },
+    {
+      "id": "939336",
+      "title": {
+        "ja": "EncryptedSharedPreferences が deprecated になっちゃった！どうしよう！",
+        "en": "Oh no! EncryptedSharedPreferences has been deprecated! What should I do?"
+      },
+      "description": "EncryptedSharedPreferences など androidx.security:security-crypto ライブラリの全ての API が version 1.1.0-alpha07 で Deprecated になりました。\r\nこのセッションでは androidx.security:security-crypto がそもそもどういうライブラリなのか、どのような機能を提供しているのかを紹介します。\r\n次に代替となるプラットフォーム API および Android Keystore などについて解説します。最後に androidx.security:security-crypto から代替方法へのマイグレーションを解説します。\r\n",
+      "i18nDesc": {
+        "ja": "EncryptedSharedPreferences など androidx.security:security-crypto ライブラリの全ての API が version 1.1.0-alpha07 で Deprecated になりました。\nこのセッションでは androidx.security:security-crypto がそもそもどういうライブラリなのか、どのような機能を提供しているのかを紹介します。\n次に代替となるプラットフォーム API および Android Keystore などについて解説します。最後に androidx.security:security-crypto から代替方法へのマイグレーションを解説します。",
+        "en": "EncryptedSharedPreferences—and, in fact, every API in the androidx.security:security-crypto library—has been deprecated in version 1.1.0-alpha07. In this session, we will introduce what the androidx.security:security-crypto library is and the functionality it provides. Then, we will go over alternative platform APIs such as the Android Keystore. Finally, we will explain how to migrate from androidx.security:security-crypto to these alternatives.\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-12T17:20:00+09:00",
+      "endsAt": "2025-09-12T18:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "580fb501-aece-4bf4-b755-32fda033b3bd"
+      ],
+      "roomId": 64802,
+      "targetAudience": "androidx.security:security-crypto を利用したことがある人\r\nAndroid Keystore などに興味がある人\r\n",
+      "i18nTargetAudience": {
+        "ja": "androidx.security:security-crypto を利用したことがある人\nAndroid Keystore などに興味がある人",
+        "en": "People who have used androidx.security:security-crypto\nPeople interested in the Android Keystore, etc."
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361160,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "921565",
+      "title": {
+        "ja": "WebViewとはさようなら：KMP + Composeによるサーバー駆動UI",
+        "en": "Breaking Up with WebViews: Server-Driven UI with KMP + Compose"
+      },
+      "description": "Server Driven Cross-Platform UI Revolution to Take Over WebViews\r\n\r\nWebViews are everywhere, they\u0027re fast to deploy, easy to update, and flexible. But they’re also brittle, hard to maintain, and pose serious security risks to the app specially for fintech domain. We asked ourselves: Is there a better way to deliver dynamic content across platforms without the WebView baggage?\r\n\r\nIn this session, we’ll share how we’re replacing WebViews with a fully native, server-driven UI framework built using Kotlin Multiplatform and Jetpack Compose Multiplatform. \r\n\r\nYou’ll get a deep dive into how we designed our dynamic UI engine, how we defined a JSON-based UI schema, and how we ensured performance and flexibility across Android, iOS and Desktop too all in a single Kotlin codebase.\r\n\r\nExpect real-world lessons from our rollout, performance benchmarks, and how Compose Multiplatform helped us build fast without learning Flutter or React Native.\r\n\r\nIf you’re tired of maintaining complex WebViews and want a modern, secure, cross-platform Kotlin-native solution for dynamic UI, this talk is for you.",
+      "i18nDesc": {
+        "ja": "WebViewに代わる、サーバー駆動のクロスプラットフォームUIがどのように革命を起こすのかについて説明します。\nWebViewは至る所に使われており、展開も更新も容易で、柔軟性に富んでいます。しかし、その反面、脆弱で保守性に欠け、特にフィンテック領域ではアプリの重大なセキュリティリスクともなり得ます。そこで私たちはこう自問しました：WebViewに頼らずに、複数プラットフォームで動的なコンテンツを提供できる、より良い方法はあるでしょうか？\n本セッションでは、Kotlin Multiplatform と Jetpack Compose Multiplatform を用いて構築した、完全にネイティブでサーバー駆動のUIフレームワークを、どのようにしてWebViewに代えて導入したかをご紹介します。\n動的UIエンジンの設計方法・JSONベースのUIスキーマ定義の手法・Android、iOS、デスクトップの各プラットフォームにおけるパフォーマンスと柔軟性を担保しつつ単一のKotlinコードベースで実現した内容を深掘りします。\nさらに、実運用中に得られたリアルな知見、パフォーマンスベンチマーク、そして Flutter や React Native を学ぶことなく、Compose Multiplatform を使って高速に開発を進める方法についても触れます。\n「WebViewの複雑な保守に疲れた」「動的UIのためにモダンで安全、クロスプラットフォームなKotlinネイティブなソリューションが欲しい」という方には、本講演が最適です。\n\n（DroidKaigi実行委員会による翻訳）",
+        "en": "Server Driven Cross-Platform UI Revolution to Take Over WebViews\n\nWebViews are everywhere, they\u0027re fast to deploy, easy to update, and flexible. But they’re also brittle, hard to maintain, and pose serious security risks to the app specially for fintech domain. We asked ourselves: Is there a better way to deliver dynamic content across platforms without the WebView baggage?\n\nIn this session, we’ll share how we’re replacing WebViews with a fully native, server-driven UI framework built using Kotlin Multiplatform and Jetpack Compose Multiplatform.\n\nYou’ll get a deep dive into how we designed our dynamic UI engine, how we defined a JSON-based UI schema, and how we ensured performance and flexibility across Android, iOS and Desktop too all in a single Kotlin codebase.\n\nExpect real-world lessons from our rollout, performance benchmarks, and how Compose Multiplatform helped us build fast without learning Flutter or React Native.\n\nIf you’re tired of maintaining complex WebViews and want a modern, secure, cross-platform Kotlin-native solution for dynamic UI, this talk is for you."
+      },
+      "startsAt": "2025-09-11T16:20:00+09:00",
+      "endsAt": "2025-09-11T17:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "f5d23f70-1198-46ff-b1c9-a6e6e8a9af62"
+      ],
+      "roomId": 64800,
+      "targetAudience": "Android developers looking to move beyond WebViews for dynamic content\r\nEngineers building or maintaining Kotlin Multiplatform projects\r\nDevelopers interested in Server-Driven UI architecture\r\nTeams exploring Compose Multiplatform for cross-platform development\r\nMobile architects seeking scalable, maintainable cross-platform solutions",
+      "i18nTargetAudience": {
+        "ja": "動的コンテンツのために WebViewを卒業したい Android開発者\n\nKotlin Multiplatformプロジェクトの 構築または運用に携わるエンジニア\n\nサーバー駆動UIアーキテクチャ に関心のある開発者\n\nCompose Multiplatformを使った クロスプラットフォーム開発 に関心のあるチーム\n\nスケーラブルで保守性に優れたクロスプラットフォーム設計 を目指すモバイルアーキテクト",
+        "en": "Android developers looking to move beyond WebViews for dynamic content\nEngineers building or maintaining Kotlin Multiplatform projects\nDevelopers interested in Server-Driven UI architecture\nTeams exploring Compose Multiplatform for cross-platform development\nMobile architects seeking scalable, maintainable cross-platform solutions"
+      },
+      "language": "ENGLISH",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361171,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": true,
+        "en": false
+      }
+    },
+    {
+      "id": "946868",
+      "title": {
+        "ja": "Androidエンジニアとしてのキャリア",
+        "en": "Careers as an Android Engineer"
+      },
+      "description": "「キャリアを考えたとき漠然とした不安がある」「自分の将来像を想像できない」とキャリアについて相談されることがよくあります。\r\nそのような相談を受けるとき、相手が必要としているのは「輝かしいキャリア戦略」や「成功へのロードマップ」といった\r\n世の中にあふれる、わかりやすい話ではなく悩む気持ちを行動に変えるキッカケだと考えています。\r\n\r\nうーん、将来に少し困ったなと感じて参考を求めて「あなたのキャリア論を聞いてみたいと話しても「いやいや、そんな自分のやり方なんて再現性がないよ」と断られることもよくあります。\r\n\r\n「再現性がない」という言葉は、経験してきたプロジェクトの特殊性、技術選定の経緯、そして個人的な興味の変遷など、\r\nキャリアと呼んでいる道が不確実性の高い選択が背景にあります。「計画性のなさ」を感じる状況では、その人の昇格、転職やロールチェンジといった重要な意思決定のプロセスが、時々で得られていたスキル、過去の経験など自分自身を構成している価値観から導かれている現実があります。\r\n\r\nこのセッションでは、そんな「再現性がない」「計画性のなさ」と感じるキャリアについて「意思決定のプロセス」自体に学びを求めます。\r\n\r\nAndroidアプリ開発経験10年以上のエンジニアとしての経験、エンジニアリングマネージャとしての経験、複数の事業立ち上げといったビジネス経験をふまえ、\r\nシニアなエンジニアが何を考えているのかという実例から再現性のないキャリアだからこそ語れる、リアルな経験と学びを共有します。",
+      "i18nDesc": {
+        "ja": "「キャリアを考えたとき漠然とした不安がある」「自分の将来像を想像できない」とキャリアについて相談されることがよくあります。\nそのような相談を受けるとき、相手が必要としているのは「輝かしいキャリア戦略」や「成功へのロードマップ」といった\n世の中にあふれる、わかりやすい話ではなく悩む気持ちを行動に変えるキッカケだと考えています。\n\nうーん、将来に少し困ったなと感じて参考を求めて「あなたのキャリア論を聞いてみたいと話しても「いやいや、そんな自分のやり方なんて再現性がないよ」と断られることもよくあります。\n\n「再現性がない」という言葉は、経験してきたプロジェクトの特殊性、技術選定の経緯、そして個人的な興味の変遷など、\nキャリアと呼んでいる道が不確実性の高い選択が背景にあります。「計画性のなさ」を感じる状況では、その人の昇格、転職やロールチェンジといった重要な意思決定のプロセスが、時々で得られていたスキル、過去の経験など自分自身を構成している価値観から導かれている現実があります。\n\nこのセッションでは、そんな「再現性がない」「計画性のなさ」と感じるキャリアについて「意思決定のプロセス」自体に学びを求めます。\n\nAndroidアプリ開発経験10年以上のエンジニアとしての経験、エンジニアリングマネージャとしての経験、複数の事業立ち上げといったビジネス経験をふまえ、\nシニアなエンジニアが何を考えているのかという実例から再現性のないキャリアだからこそ語れる、リアルな経験と学びを共有します。",
+        "en": "I am often asked for career advice by people who say, “I feel a vague anxiety when I think about my career,” or “I can’t picture my future self.”\nWhen someone seeks this kind of advice, what they truly need is not an easy-to-digest talk about a “brilliant career strategy” or a “roadmap to success” that floods the world, but rather a trigger that turns their worries into action.\n\nSometimes, when you approach someone for inspiration—saying, “I’d like to hear your views on career development”—they reply, “No, no, my path isn’t reproducible.”\n\nThe phrase “not reproducible” reflects the high-uncertainty choices behind what we call a career: the uniqueness of past projects, the history of technology selections, and the personal shifts in interests. In situations that seem “unplanned,” key decisions—promotions, job changes, or role transitions—are in fact guided by the skills acquired at each stage, past experiences, and the values that make up that person’s identity.\n\nThis session seeks to learn from the very “decision-making processes” behind careers that appear “non-reproducible” or “unplanned.”\n\nDrawing on more than ten years of Android app development, experience as an engineering manager, and business experience launching multiple ventures, I will share real-world lessons and insights that only a senior engineer with an “unreproducible” career can offer—what seasoned engineers are really thinking about and learning along the way.\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-11T16:20:00+09:00",
+      "endsAt": "2025-09-11T17:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "b884cf72-b5c9-471b-a874-7f0ba379561d"
+      ],
+      "roomId": 64801,
+      "targetAudience": " - Androidエンジニアとしてキャリアに不安がある人\r\n - キャリアについて何らかなヒントが欲しい人",
+      "i18nTargetAudience": {
+        "ja": "- Androidエンジニアとしてキャリアに不安がある人\n- キャリアについて何らかなヒントが欲しい人",
+        "en": "- People who feel anxiety about their career as Android engineers\n- People who want hints or guidance about career development"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361172,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "c5bb7949-06f1-42fe-a25f-9f7bb9ef19fb",
+      "title": {
+        "ja": "特定のテーマで話せるミートアップ",
+        "en": "Themed Meetups"
+      },
+      "description": "様々なテーマごとに集まって、ランチやおやつを食べながら交流しましょう。\nテーマは開催時間ごとに違うものをご用意しています。興味があるテーマを見つけてぜひご参加ください。\n席に限りがありますので、参加を希望される方はお時間になりましたらお早めにお越しください。なお、ランチタイムのミートアップにはお弁当受け取り後にお越しください。\n\n9/11(木) 13:00-14:20：女性、English Speaking、首都圏以外から参加\n9/12(金) 13:00-14:20：Android初学者、一人で開発、子育てと仕事\n9/12(金) 16:20-17:00：AI活用、マネジメント、キャリアプラン",
+      "i18nDesc": {
+        "ja": "様々なテーマごとに集まって、ランチやおやつを食べながら交流しましょう。\nテーマは開催時間ごとに違うものをご用意しています。興味があるテーマを見つけてぜひご参加ください。\n席に限りがありますので、参加を希望される方はお時間になりましたらお早めにお越しください。なお、ランチタイムのミートアップにはお弁当受け取り後にお越しください。\n\n9/11(木) 13:00-14:20：女性、English Speaking、首都圏以外から参加\n9/12(金) 13:00-14:20：Android初学者、一人で開発、子育てと仕事\n9/12(金) 16:20-17:00：AI活用、マネジメント、キャリアプラン",
+        "en": "Let\u0027s gather around various themes and engage in conversations over lunch or snacks. Each session features a different theme, so find one that interests you and join us!\nPlease note that seating is limited. If you wish to participate, kindly arrive promptly at the scheduled time. For lunch-time meetups, please pick up your lunch before joining.\n\nThu, 11 Sep 2025 13:00-14:20 : Women, English Speaking, Participating from outside the Tokyo metropolitan area\nFri, 12 Sep 2025 13:00-14:20 : Android Beginners, Solo Developer, Parenting and Work\nFri, 12 Sep 2025 16:20-17:00 : AI utilization, Management, Career Plans"
+      },
+      "startsAt": "2025-09-11T13:00:00+09:00",
+      "endsAt": "2025-09-11T14:20:00+09:00",
+      "isServiceSession": true,
+      "isPlenumSession": false,
+      "speakers": [],
+      "roomId": 64803,
+      "targetAudience": "TBW",
+      "i18nTargetAudience": {
+        "ja": "TBW",
+        "en": "TBW"
+      },
+      "language": "MIXED",
+      "lengthInMinutes": 80,
+      "sessionCategoryItemId": 361173,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "BEGINNER",
+        "INTERMEDIATE",
+        "ADVANCED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": true,
+        "en": true
+      }
+    },
+    {
+      "id": "981378",
+      "title": {
+        "ja": "スマホ新法って何？１２月施行？アプリビジネスに影響あるの？",
+        "en": "What Is Japan\u0027s Mobile Software Competition Act Effective this December? —How Will It Affect the App Business?"
+      },
+      "description": "今年１２月に施行が予定されている新しい法律、スマホソフトウェア競争促進法（スマホ新法）。\r\nこの法律がアプリビジネスにどのような影響を与えるのか、エンジニアのみなさまにどんな関係があるのか、公正取引委員会の担当者が解説します。\r\n例えば、\r\n・OS機能（通信機能等）の利用可能性の向上\r\n・新たなアプリストアの登場など決済手段の多様化\r\n・ウェブサイト等のアプリ外での商品提供の拡大\r\n・ソフトウェアの切替え時におけるデータ移転の円滑化\r\n・ユーザーによるブラウザや検索サービスの選択の促進\r\nなどなど、これから見込まれる「変化」について説明します。\r\n",
+      "i18nDesc": {
+        "ja": "今年１２月に施行が予定されている新しい法律、スマホソフトウェア競争促進法（スマホ新法）。\nこの法律がアプリビジネスにどのような影響を与えるのか、エンジニアのみなさまにどんな関係があるのか、公正取引委員会の担当者が解説します。\n例えば、\n・OS機能（通信機能等）の利用可能性の向上\n・新たなアプリストアの登場など決済手段の多様化\n・ウェブサイト等のアプリ外での商品提供の拡大\n・ソフトウェアの切替え時におけるデータ移転の円滑化\n・ユーザーによるブラウザや検索サービスの選択の促進\nなどなど、これから見込まれる「変化」について説明します。",
+        "en": "A new law, Mobile Software Competition Act (MSCA), is scheduled to take effect this December. This session will explore how this law will impact the app business and what it means for engineers. A representative from the Japan Fair Trade Commission will provide insights into the law\u0027s provisions and implications.\n\nKey topics include:\n- Enhanced accessibility to OS features (e.g., communication functions)\n- Diversification of payment methods and app platforms through the emergence of new payment systems and alternative app stores\n- Expansion of product offerings outside of apps, such as through websites\n- Facilitation of data transfer during software transitions\n- Promotion of user choice in browsers and search services\n\nThis session will delve into these anticipated changes and their potential effects on the app industry.\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-12T14:20:00+09:00",
+      "endsAt": "2025-09-12T15:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "5eacc5a4-dc67-408c-abab-110e92e1b866"
+      ],
+      "roomId": 64802,
+      "targetAudience": "TBW",
+      "i18nTargetAudience": {
+        "ja": "TBW",
+        "en": "TBW"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361173,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "946165",
+      "title": {
+        "ja": "デザイナーがAndroidエンジニアに挑戦してみた",
+        "en": "A Designer’s Challenge to Become an Android Engineer"
+      },
+      "description": "UX/UIデザイナーとしてキャリアを積んできた本人が、実プロジェクトでAndroidエンジニアに挑戦した経験を通じて得られた気づきや学びを共有します。\r\n\r\n特にJetpack ComposeとFigmaの設計思想に共通点を感じた点や、Kotlinの可読性・記述性の高さがデザイナーにとってもとっつきやすかったこと、さらには「デザイン」と「実装」の両方の視点を持つことで、仕様調整やコミュニケーションが格段にスムーズになったことなど、デザイナーならではの視点で開発プロセスを紐解きます。\r\n\r\nこれからAndroid開発を始めてみたいと考えているデザイナーの方や、デザイナーとの連携に課題を感じているエンジニアの方にとって、役立つ視点をお届けできればと思います。\r\n\r\n1. なぜAndroid開発に挑戦したのか\r\n2. Jetpack ComposeとFigma：共通するUI設計の考え方\r\n3. Kotlinを書いて感じた「デザイナーにとっての書きやすさ」\r\n4. UI実装を通じて見えた、仕様調整のスムーズさ\r\n5. チーム開発の中で得た気づきと、コミュニケーションの変化\r\n6. これから挑戦したい人へのメッセージ",
+      "i18nDesc": {
+        "ja": "UX/UIデザイナーとしてキャリアを積んできた本人が、実プロジェクトでAndroidエンジニアに挑戦した経験を通じて得られた気づきや学びを共有します。\n\n特にJetpack ComposeとFigmaの設計思想に共通点を感じた点や、Kotlinの可読性・記述性の高さがデザイナーにとってもとっつきやすかったこと、さらには「デザイン」と「実装」の両方の視点を持つことで、仕様調整やコミュニケーションが格段にスムーズになったことなど、デザイナーならではの視点で開発プロセスを紐解きます。\n\nこれからAndroid開発を始めてみたいと考えているデザイナーの方や、デザイナーとの連携に課題を感じているエンジニアの方にとって、役立つ視点をお届けできればと思います。\n\n1. なぜAndroid開発に挑戦したのか\n2. Jetpack ComposeとFigma：共通するUI設計の考え方\n3. Kotlinを書いて感じた「デザイナーにとっての書きやすさ」\n4. UI実装を通じて見えた、仕様調整のスムーズさ\n5. チーム開発の中で得た気づきと、コミュニケーションの変化\n6. これから挑戦したい人へのメッセージ",
+        "en": "As a seasoned UX/UI designer, I share the insights and lessons gained from stepping into the role of an Android engineer on an actual project.\n\nI found striking similarities between the design philosophies of JetpackCompose and Figma, discovered Kotlin’s high readability and expressiveness approachable even for designers, and realized that possessing perspectives on both “design” and “implementation” made specification adjustments and communication far smoother. From a designer’s unique standpoint, I unravel the development process.\n\nI hope these perspectives will be helpful for designers considering Android development and for engineers facing collaboration challenges with designers.\n\n1. Why I decided to take on Android development\n2. JetpackCompose and Figma: Shared approaches to UI design\n3. Writing Kotlin and feeling its “designer-friendly” ease of use\n4. The smooth specification adjustments revealed through UI implementation\n5. Insights gained in team development and changes in communication\n6. A message for those eager to take on the challenge next\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-11T16:20:00+09:00",
+      "endsAt": "2025-09-11T17:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "8d8bc766-ef90-487c-ac92-790f21ebccbf"
+      ],
+      "roomId": 64799,
+      "targetAudience": "- デザイナーとして働いていて、Android開発に興味がある方\r\n- Androidエンジニアとして、デザイナーとの連携に悩んでいる方\r\n- 職種の垣根を越えた「ものづくり」に関心のあるすべての開発者",
+      "i18nTargetAudience": {
+        "ja": "- デザイナーとして働いていて、Android開発に興味がある方\n- Androidエンジニアとして、デザイナーとの連携に悩んでいる方\n- 職種の垣根を越えた「ものづくり」に関心のあるすべての開発者",
+        "en": "- Designers interested in Android development\n- Android engineers struggling to collaborate with designers\n- All developers curious about “making things” beyond job boundaries"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361161,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "939376",
+      "title": {
+        "ja": "例外のその先へ：セーフティクリティカル原則に基づき堅牢なAndroidアプリを構築する",
+        "en": "Beyond Exceptions: Building Resilient Android Apps with Safety-Critical Principles"
+      },
+      "description": "When your Android app crashes, users uninstall. This session explores how to handle failures before they become crashes, focusing on Android\u0027s unique reliability challenges.\r\n\r\nWe\u0027ll establish the critical distinction between domain errors (expected business logic failures) and system failures (unrecoverable hardware/OS issues), implementing each with appropriate strategies. You\u0027ll learn to build a custom Result monad that provides compile-time safety beyond Kotlin\u0027s built-in limitations, and we\u0027ll see how NASA\u0027s mission-critical safety rules can be applied in the Android world. You\u0027ll also master native crash debugging techniques for those unavoidable system failures.\r\n\r\nFrom handling hardware state corruption to graceful degradation under memory pressure, you\u0027ll walk away with battle-tested patterns for Android\u0027s trickiest reliability scenarios: complex state management, native code integration, and building apps that degrade gracefully rather than crash catastrophically.\r\n\r\nTarget audience: Individual contributors and engineering managers looking to improve app stability and reduce crash rates through principled error handling.",
+      "i18nDesc": {
+        "ja": "Androidアプリがクラッシュすると、ユーザーはアンインストールしてしまいます。本セッションでは、Android特有の信頼性に関する課題に焦点を当て、アプリがクラッシュする前にどのように対処するかを探ります。\nドメインエラー（想定されたビジネスロジックにおける失敗）とシステム障害（回復不能なハードウェア/OSの問題）との決定的な違いを確立し、それぞれに適切な戦略を適用する方法を説明します。Kotlinの組み込みの制限を超えたコンパイル時安全性を提供するカスタムResultモナドの構築方法を学び、NASAのミッションクリティカルな安全規則がAndroidの世界でどのように適用できるかを見ていきます。また、避けられないシステム障害に対するネイティブクラッシュデバッグ技術も習得します。\nハードウェアの状態破損の処理からメモリ負荷時の適切なデグレーションの手法まで、Androidの最もトリッキーな信頼性シナリオ（複雑な状態管理、ネイティブコード統合、致命的なクラッシュではなく適切にデグレーションするアプリの構築）に対する実証済みのパターンを習得できます。\n\n（DroidKaigi実行委員会による翻訳）",
+        "en": "When your Android app crashes, users uninstall. This session explores how to handle failures before they become crashes, focusing on Android\u0027s unique reliability challenges.\n\nWe\u0027ll establish the critical distinction between domain errors (expected business logic failures) and system failures (unrecoverable hardware/OS issues), implementing each with appropriate strategies. You\u0027ll learn to build a custom Result monad that provides compile-time safety beyond Kotlin\u0027s built-in limitations, and we\u0027ll see how NASA\u0027s mission-critical safety rules can be applied in the Android world. You\u0027ll also master native crash debugging techniques for those unavoidable system failures.\n\nFrom handling hardware state corruption to graceful degradation under memory pressure, you\u0027ll walk away with battle-tested patterns for Android\u0027s trickiest reliability scenarios: complex state management, native code integration, and building apps that degrade gracefully rather than crash catastrophically.\n\nTarget audience: Individual contributors and engineering managers looking to improve app stability and reduce crash rates through principled error handling."
+      },
+      "startsAt": "2025-09-11T16:20:00+09:00",
+      "endsAt": "2025-09-11T17:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "be3e11c4-594c-40ae-875f-03f64536f86e"
+      ],
+      "roomId": 64802,
+      "targetAudience": "Individual contributors and engineering managers looking to improve app stability and reduce crash rates through principled error handling.",
+      "i18nTargetAudience": {
+        "ja": "アプリの安定性を向上させ、クラッシュ率を削減するために、原則に基づいたエラーハンドリングを探している個々のコントリビューターおよびエンジニアリングマネージャー。",
+        "en": "Individual contributors and engineering managers looking to improve app stability and reduce crash rates through principled error handling."
+      },
+      "language": "ENGLISH",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361164,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": true,
+        "en": false
+      }
+    },
+    {
+      "id": "6015551d-2770-4017-88eb-c54cd6e0570b",
+      "title": {
+        "ja": "After Party 🎉",
+        "en": "After Party 🎉"
+      },
+      "description": null,
+      "i18nDesc": {
+        "ja": "After Party 🎉",
+        "en": "After Party 🎉"
+      },
+      "startsAt": "2025-09-11T17:20:00+09:00",
+      "endsAt": "2025-09-11T19:20:00+09:00",
+      "isServiceSession": true,
+      "isPlenumSession": false,
+      "speakers": [],
+      "roomId": 64803,
+      "targetAudience": "TBW",
+      "i18nTargetAudience": {
+        "ja": "TBW",
+        "en": "TBW"
+      },
+      "language": "MIXED",
+      "lengthInMinutes": 120,
+      "sessionCategoryItemId": 361173,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": false
+      }
+    },
+    {
+      "id": "927634",
+      "title": {
+        "ja": "AndroidとKotlin Multiplatformで産業グレードのRFIDシステムを構築する",
+        "en": "Building Industrial-Grade RFID Systems with Android and Kotlin Multiplatform"
+      },
+      "description": "多くのAndroid開発者はコンシューマー向けアプリケーションに焦点を当てていますが、Androidの真の可能性は工業用途にこそあります。本セッションでは、RFIDリーダーとAndroidデバイスを連携させ、堅牢な産業用IoTシステムを構築するための実践的アプローチを紹介します。\r\n\r\nAndroidは従来、産業用途では特殊な専用端末が必要とされていましたが、Web Serial APIとKotlin Multiplatformを組み合わせることで、標準的なAndroidデバイスを産業グレードのRFID管理システムへと変貌させることが可能になりました。\r\n\r\nこのセッションでは、以下の内容について具体的な実装例とともに解説します：\r\n\r\n• AndroidデバイスでWeb Serial APIを使用したRFID通信の実装方法\r\n• Kotlin Multiplatformを活用したクロスプラットフォームRFIDライブラリの設計\r\n• 断続的な接続環境下でもデータ整合性を維持する同期パターン\r\n• 産業用AndroidアプリケーションのためのセキュリティアーキテクチャとZero Trustの実装\r\n• センサーデータストリームをリアルタイムで処理するパフォーマンス最適化テクニック\r\n• Jetpack Composeを使用した産業用モニタリングダッシュボードの構築\r\n\r\nこれは理論的な話ではなく、実際の製造環境で検証された実装技術です。セッション後は、Androidを活用して産業用途の課題を解決するための実践的なアプローチを身につけることができます。\r\n\r\nこのアプローチにより、開発者はコンシューマー向けアプリケーション以外の新たな可能性を発見し、Androidの応用範囲を大幅に拡張することができるでしょう。",
+      "i18nDesc": {
+        "ja": "多くのAndroid開発者はコンシューマー向けアプリケーションに焦点を当てていますが、Androidの真の可能性は工業用途にこそあります。本セッションでは、RFIDリーダーとAndroidデバイスを連携させ、堅牢な産業用IoTシステムを構築するための実践的アプローチを紹介します。\n\nAndroidは従来、産業用途では特殊な専用端末が必要とされていましたが、Web Serial APIとKotlin Multiplatformを組み合わせることで、標準的なAndroidデバイスを産業グレードのRFID管理システムへと変貌させることが可能になりました。\n\nこのセッションでは、以下の内容について具体的な実装例とともに解説します：\n\n• AndroidデバイスでWeb Serial APIを使用したRFID通信の実装方法\n• Kotlin Multiplatformを活用したクロスプラットフォームRFIDライブラリの設計\n• 断続的な接続環境下でもデータ整合性を維持する同期パターン\n• 産業用AndroidアプリケーションのためのセキュリティアーキテクチャとZero Trustの実装\n• センサーデータストリームをリアルタイムで処理するパフォーマンス最適化テクニック\n• Jetpack Composeを使用した産業用モニタリングダッシュボードの構築\n\nこれは理論的な話ではなく、実際の製造環境で検証された実装技術です。セッション後は、Androidを活用して産業用途の課題を解決するための実践的なアプローチを身につけることができます。\n\nこのアプローチにより、開発者はコンシューマー向けアプリケーション以外の新たな可能性を発見し、Androidの応用範囲を大幅に拡張することができるでしょう。\n\n（DroidKaigi実行委員会による翻訳）",
+        "en": "Many Android developers focus on consumer-facing applications, but Android’s true potential lies in industrial use cases. In this session, we present a hands-on approach to building a robust industrial IoT system by connecting an RFID reader to an Android device.\n\nTraditionally, industrial deployments required specialized Android hardware, but by combining the Web Serial API with Kotlin Multiplatform, you can transform a standard Android device into an industrial-grade RFID management system.\n\nIn this session, we will explain the following topics with concrete implementation examples:\n\n• How to implement RFID communication on Android devices using the Web Serial API\n• Designing a cross-platform RFID library with Kotlin Multiplatform\n• Synchronization patterns that preserve data consistency even under intermittent connectivity\n• A security architecture for industrial Android applications and the implementation of Zero Trust\n• Performance-tuning techniques for processing sensor data streams in real time\n• Building an industrial monitoring dashboard with Jetpack Compose\n\nThis is not theory; the techniques have been validated in real manufacturing environments. After the session, you will have a practical approach for solving industrial challenges with Android.\n\nWith this approach, developers can discover new possibilities beyond consumer applications and dramatically expand Android’s field of application."
+      },
+      "startsAt": "2025-09-11T11:20:00+09:00",
+      "endsAt": "2025-09-11T12:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "b1ec342f-e6bf-4887-8d48-a2c5bbc017ff"
+      ],
+      "roomId": 64799,
+      "targetAudience": "このセッションは、産業用途でのAndroidアプリケーション開発に興味がある中級から上級レベルのAndroid開発者向けです。Kotlin、Kotlin Multiplatformの基礎知識があり、IoTシステムや産業アプリケーションの可能性を探求したい方に最適です。一般的なアプリ開発を超えて、Androidの産業活用を学びたい開発者にとって価値ある内容です。\r\n\r\nThis session is for intermediate to advanced Android developers interested in industrial applications of Android. Ideal for those with basic knowledge of Kotlin and Kotlin Multiplatform who want to explore possibilities in IoT systems and industrial applications. Perfect for developers looking to expand beyond consumer apps into the realm of industrial Android utilisation.",
+      "i18nTargetAudience": {
+        "ja": "このセッションは、産業用途でのAndroidアプリケーション開発に興味がある中級から上級レベルのAndroid開発者向けです。Kotlin、Kotlin Multiplatformの基礎知識があり、IoTシステムや産業アプリケーションの可能性を探求したい方に最適です。一般的なアプリ開発を超えて、Androidの産業活用を学びたい開発者にとって価値ある内容です。",
+        "en": "This session is for intermediate to advanced Android developers interested in industrial applications of Android. Ideal for those with basic knowledge of Kotlin and Kotlin Multiplatform who want to explore possibilities in IoT systems and industrial applications. Perfect for developers looking to expand beyond consumer apps into the realm of industrial Android utilisation."
+      },
+      "language": "ENGLISH",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361171,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": true,
+        "en": false
+      }
+    },
+    {
+      "id": "943982",
+      "title": {
+        "ja": "「どこから読む？」コードとカルチャーに最速で馴染むための実践ガイド〜新メンバーを活躍に導くオンボーディング戦略〜",
+        "en": "\"Where Do I Start Reading?\" A Practical Guide to Getting Up to Speed with Code and Culture — Onboarding Strategies to Empower New Team Members"
+      },
+      "description": "「どこから読めばいいんだろう？」新しいAndroidチームに加わった際、多くの新メンバーが直面する疑問です。一方で、チーム側も、明確なオンボーディングプロセスや最新のドキュメントがないために、新メンバーの立ち上がりが遅れたり、「キャッチアップはOJTで」と既存メンバーの負担が増えたりする課題を抱えています。特に、技術スタックの多様化（例: ViewとComposeの共存）やプロジェクトの規模拡大は、このオンボーディングの難易度を一層高めています。\r\n\r\n本セッションでは、Androidチームが新メンバーを迎え入れ、早期にプロジェクトに貢献し、自信を持ってキャッチアップできるようになるための効果的なオンボーディング戦略と、実践的なドキュメント整備・知識共有の方法に焦点を当てて解説します。新メンバーが「どこから進めればいいか」を明確にし、主体的に学べる環境をどのように作るか、そしてチーム全体の生産性向上と、新メンバーのエンゲージメントを高めるための具体的な施策を、チームでの試行錯誤や成功事例を交えて紹介します。\r\n\r\n具体的なセッション内容は以下を予定しております。\r\n・巨大・レガシーコードベースの読み解き方\r\n(どこからコードを読み始めるべきか、どのように全体像を掴むか、デバッグツール や静的解析ツールを活用したコード理解の方法)\r\n\r\n・プロジェクト固有の技術/アーキテクチャの理解\r\n(アプリの主要なアーキテクチャパターン (MVVM、 Clean Architectureなど)、DI、マルチモジュール構成 の理解方法。ViewModel やContext といった主要な概念の実践的な使い分け。)\r\n\r\n・開発に必要な周辺知識のキャッチアップ\r\n(テストコードの読み方・書き方、難読化、セキュリティ、パフォーマンス測定 といった専門領域の概要理解。)\r\n\r\n・「最低限これだけは必要」なドキュメントとは\r\n(アーキテクチャ概要、ビルド手順、デバッグ方法、よくある質問(FAQ)、主要機能の説明など、新メンバーがまず参照すべきドキュメントの項目。)\r\n\r\n・ドキュメントを陳腐化させない運用方法\r\n(ドキュメント更新を開発プロセスに組み込む工夫、誰が・いつ・どのように更新するか。)",
+      "i18nDesc": {
+        "ja": "「どこから読めばいいんだろう？」新しいAndroidチームに加わった際、多くの新メンバーが直面する疑問です。一方で、チーム側も、明確なオンボーディングプロセスや最新のドキュメントがないために、新メンバーの立ち上がりが遅れたり、「キャッチアップはOJTで」と既存メンバーの負担が増えたりする課題を抱えています。特に、技術スタックの多様化（例: ViewとComposeの共存）やプロジェクトの規模拡大は、このオンボーディングの難易度を一層高めています。\n\n本セッションでは、Androidチームが新メンバーを迎え入れ、早期にプロジェクトに貢献し、自信を持ってキャッチアップできるようになるための効果的なオンボーディング戦略と、実践的なドキュメント整備・知識共有の方法に焦点を当てて解説します。新メンバーが「どこから進めればいいか」を明確にし、主体的に学べる環境をどのように作るか、そしてチーム全体の生産性向上と、新メンバーのエンゲージメントを高めるための具体的な施策を、チームでの試行錯誤や成功事例を交えて紹介します。\n\n具体的なセッション内容は以下を予定しております。\n・巨大・レガシーコードベースの読み解き方\n(どこからコードを読み始めるべきか、どのように全体像を掴むか、デバッグツール や静的解析ツールを活用したコード理解の方法)\n\n・プロジェクト固有の技術/アーキテクチャの理解\n(アプリの主要なアーキテクチャパターン (MVVM、 Clean Architectureなど)、DI、マルチモジュール構成 の理解方法。ViewModel やContext といった主要な概念の実践的な使い分け。)\n\n・開発に必要な周辺知識のキャッチアップ\n(テストコードの読み方・書き方、難読化、セキュリティ、パフォーマンス測定 といった専門領域の概要理解。)\n\n・「最低限これだけは必要」なドキュメントとは\n(アーキテクチャ概要、ビルド手順、デバッグ方法、よくある質問(FAQ)、主要機能の説明など、新メンバーがまず参照すべきドキュメントの項目。)\n\n・ドキュメントを陳腐化させない運用方法\n(ドキュメント更新を開発プロセスに組み込む工夫、誰が・いつ・どのように更新するか。)",
+        "en": "“When you join a new Android team, the first question is often, ‘Where should I start reading the code?’” Many newcomers face this problem. Meanwhile, teams without a clear onboarding process or up-to-date documentation see slower ramp-ups and heavier burdens on existing members with “catching up through OJTs”. The diversification of tech stacks (e.g., View and Compose coexisting) and growing project size make onboarding even harder.\n\nThis session explains effective onboarding strategies and pragmatic methods for documentation and knowledge sharing so Android teams can help new members contribute quickly and confidently. We’ll show how to create an environment where newcomers know exactly “where to begin,” learn proactively, and boost both team productivity and engagement, illustrated with real-world experiments and success stories.\n\nSession topics include:\n- How to dissect large, legacy codebases\n (Where to start reading, how to grasp the big picture, and how to use debugging and static-analysis tools to understand code.)\n\n- Understanding project-specific technology and architecture\n (Comprehending key patterns such as MVVM and Clean Architecture, dependency injection, multi-module setups, and practical distinctions of concepts like ViewModel and Context.)\n\n- Catching up on surrounding knowledge needed for development\n (Overview of specialized areas such as test code, obfuscation, security, and performance measurement.)\n\n- What makes “minimum viable” documentation\n (Architecture overview, build steps, debugging methods, FAQs, key-feature explanations—items newcomers should consult first.)\n\n- How to keep documentation from going stale\n (Embedding updates into the development process: who updates, when, and how.)\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-12T12:20:00+09:00",
+      "endsAt": "2025-09-12T13:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "2012ef2f-df29-44e5-ba09-b586c20b947b"
+      ],
+      "roomId": 64802,
+      "targetAudience": "・Androidプロジェクトに新しくジョインしたばかりのエンジニア\r\n・これから新しいAndroidチームに異動する予定のエンジニア\r\n・既存のAndroidコードベースの理解に苦労しているエンジニア\r\n・新メンバーのキャッチアップを支援する立場にあるエンジニア（メンター、テックリードなど）",
+      "i18nTargetAudience": {
+        "ja": "・Androidプロジェクトに新しくジョインしたばかりのエンジニア\n・これから新しいAndroidチームに異動する予定のエンジニア\n・既存のAndroidコードベースの理解に苦労しているエンジニア\n・新メンバーのキャッチアップを支援する立場にあるエンジニア（メンター、テックリードなど）",
+        "en": "- Engineers who have just joined an Android project\n- Engineers about to move to a new Android team\n- Engineers struggling to understand an existing Android codebase\n- Engineers responsible for helping newcomers ramp up (mentors, tech leads, etc.)"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361166,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "930808",
+      "title": {
+        "ja": "Flutterからネイティブへの挑戦と学び - 評価1.6から4.0への道のり",
+        "en": "Challenges and Lessons from Flutter to Native – The Journey from a 1.6 to 4.0 Rating"
+      },
+      "description": "私たちのチームは、Flutter で開発されたアプリをネイティブアプリにコンバートするという大胆なプロジェクトに取り組みました。\r\n\r\n結果的にプロジェクトは完了し、ネイティブアプリとして新しくアプリをリリースしました。\r\n\r\nしかしリリース後、アプリの評価が4.2から1.6まで下落するという事態に直面しました。アプリが頻繁にクラッシュしたり、動作が重くなり品質が低下したため、ユーザーからの厳しいフィードバックが続いた結果です。\r\n\r\nなぜこのような品質となってしまったのでしょうか？それにはいくつかの要因があります。\r\n\r\n1つは、Flutter からネイティブへコンバートする際の進め方の問題です。各プラットフォームに移植するにあたり、大切な観点が抜け落ちたため、実装が複雑化したのです。複雑化はバグを産みやすくし、工数を増加させ、品質の低下を招きます。同じ状況に置かれたら、多くの方が同じような道を辿る可能性があります。\r\n\r\nさらに、チームビルディングの問題です。個々がスキルを持っていても、チームとしての協力が不足し、プロジェクト全体の品質に影響を及ぼしました。今回のプロジェクトは、まさにその典型です。アプリエンジニア、デザイナ、バックエンドなど、それぞれが閉じた領域で仕事をしており、全体としての連携が不足していました。\r\n\r\nリリース後、我々はチームの改善に取り組みます。様々なプロセスを見直し、コラボレーションを強化しました。そしてコードを改善しました。これらの結果、アプリの評価を4.0まで押し上げることができました。\r\n\r\nこれらのプロセスと学びを共有します。\r\n\r\n本セッションでは、そもそもなぜ Flutter からネイティブアプリにコンバートする必要があったのか。その理由からお話しします（一般的に、この経過を辿るのは珍しいでしょう！）。そして評価が1.6まで下落した原因となる、開発のアンチパターンを紹介しつつ、どのようにして4.0まで持ち直すことができたのかを具体的に説明します。特に、技術的な改善点やチームビルディングの重要性について詳しく触れます。\r\n\r\nアプリ開発者のみならず、プロジェクトマネージャーやチームリーダーにとっても有益な内容になると思います。私たちの経験を通じて、アプリチーム開発における品質向上のためのヒントを得ていただければ幸いです。",
+      "i18nDesc": {
+        "ja": "私たちのチームは、Flutter で開発されたアプリをネイティブアプリにコンバートするという大胆なプロジェクトに取り組みました。\n\n結果的にプロジェクトは完了し、ネイティブアプリとして新しくアプリをリリースしました。\n\nしかしリリース後、アプリの評価が4.2から1.6まで下落するという事態に直面しました。アプリが頻繁にクラッシュしたり、動作が重くなり品質が低下したため、ユーザーからの厳しいフィードバックが続いた結果です。\n\nなぜこのような品質となってしまったのでしょうか？それにはいくつかの要因があります。\n\n1つは、Flutter からネイティブへコンバートする際の進め方の問題です。各プラットフォームに移植するにあたり、大切な観点が抜け落ちたため、実装が複雑化したのです。複雑化はバグを産みやすくし、工数を増加させ、品質の低下を招きます。同じ状況に置かれたら、多くの方が同じような道を辿る可能性があります。\n\nさらに、チームビルディングの問題です。個々がスキルを持っていても、チームとしての協力が不足し、プロジェクト全体の品質に影響を及ぼしました。今回のプロジェクトは、まさにその典型です。アプリエンジニア、デザイナ、バックエンドなど、それぞれが閉じた領域で仕事をしており、全体としての連携が不足していました。\n\nリリース後、我々はチームの改善に取り組みます。様々なプロセスを見直し、コラボレーションを強化しました。そしてコードを改善しました。これらの結果、アプリの評価を4.0まで押し上げることができました。\n\nこれらのプロセスと学びを共有します。\n\n本セッションでは、そもそもなぜ Flutter からネイティブアプリにコンバートする必要があったのか。その理由からお話しします（一般的に、この経過を辿るのは珍しいでしょう！）。そして評価が1.6まで下落した原因となる、開発のアンチパターンを紹介しつつ、どのようにして4.0まで持ち直すことができたのかを具体的に説明します。特に、技術的な改善点やチームビルディングの重要性について詳しく触れます。\n\nアプリ開発者のみならず、プロジェクトマネージャーやチームリーダーにとっても有益な内容になると思います。私たちの経験を通じて、アプリチーム開発における品質向上のためのヒントを得ていただければ幸いです。",
+        "en": "Our team undertook a bold project to convert an app developed with Flutter into a native application.\n\nIn the end, we were able to complete the project and we released the new app as a native application.\n\nHowever, after the release, we faced a sharp decline in the app’s rating, dropping from 4.2 to 1.6. Frequent crashes, sluggish performance, and a decline in overall quality led to harsh user feedback.\n\nWhy did the quality suffer so drastically? There were several contributing factors:\n\nOne issue was the way we approached the conversion from Flutter to native. In porting to each platform, we overlooked critical considerations, which made the implementation overly complex. This complexity bred bugs, increased workload, and degraded quality. Many teams in a similar situation might follow a similar path.\n\nAnother issue was team building. Even though individuals had the necessary skills, collaboration as a team was lacking, which impacted the project’s overall quality. In this project, app engineers, designers, and backend developers each worked in silos without sufficient coordination.\n\nAfter the release, we focused on improving the team. We reviewed various processes, strengthened collaboration, and improved the code. As a result, we succeeded in raising the app’s rating back up to 4.0.\n\nWe will share these processes and lessons.\n\nIn this session, we will first discuss why it was necessary to convert from Flutter to native (this transition is generally quite rare!). Then, we will introduce the development antipatterns that caused the rating to drop to 1.6 and explain concretely how we recovered to 4.0. We will pay particular attention to technical improvements and the importance of team building.\n\nThis session will be valuable not only for app developers but also for project managers and team leaders. Through our experience, we hope you will gain insights for improving quality in app team development.\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-12T11:20:00+09:00",
+      "endsAt": "2025-09-12T12:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "33dcf0cd-fb22-4f63-b2c3-0b2737576a46",
+        "c8f63f87-2370-4f36-bfce-1fea82cbcff6"
+      ],
+      "roomId": 64801,
+      "targetAudience": "失敗からの学びを大切にするソフトウェアエンジニア: 過去のプロジェクトからの教訓を活かして将来のプロジェクトに活かしたい方。\r\n\r\nプロジェクトマネージャー: 開発プロジェクトの管理者で、チームの協力やプロジェクト進行の最適化に関心がある方。\r\n\r\nチームリーダー/マネジメント層: チームビルディングやチームワーク強化に取り組みたいと考えているリーダーやマネージャー。",
+      "i18nTargetAudience": {
+        "ja": "失敗からの学びを大切にするソフトウェアエンジニア: 過去のプロジェクトからの教訓を活かして将来のプロジェクトに活かしたい方。\n\nプロジェクトマネージャー: 開発プロジェクトの管理者で、チームの協力やプロジェクト進行の最適化に関心がある方。\n\nチームリーダー/マネジメント層: チームビルディングやチームワーク強化に取り組みたいと考えているリーダーやマネージャー。",
+        "en": "Software engineers who value learning from failure: Those who wish to leverage lessons from past projects to improve future ones.\n\nProject managers: Individuals responsible for managing development projects who are interested in optimizing team collaboration and project progress.\n\nTeam leaders/management: Leaders or managers seeking to enhance team building and strengthen teamwork."
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361166,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "940354",
+      "title": {
+        "ja": "Android値受け渡し大全 〜設計を制する者が「渡す」を制す！〜",
+        "en": "The Complete Guide to Android Value Passing: Control Your Architecture, Control Your “Passing”!"
+      },
+      "description": "Androidアプリ開発では「この値、別のクラスに渡したい！」という場面が日常茶飯事！しかし、状況や目的によって適切な方法は異なります。どのような方法があるのか、選択肢をたくさん持っていた方が、その時の状況やプロダクトの性質に合わせた最適な手段を選択できるでしょう。また、値の受け渡しに関して切っても切り離せない関係になってくるのが設計です。\r\n\r\n本セッションでは、はじめにAndroidアプリ開発における設計の原理原則に触れたあと、どのような値の受け渡し方法があり、設計観点でどのようなメリット・デメリットがあるのかを紹介します。設計に強くなって、“いい感じ”に値が渡せるアプリを作れるようになりましょう！\r\n\r\n◆ お品書き\r\n- とりあえずこれだけは知っておこう！設計の原理原則！！\r\n    - UDF（単方向データフロー）\r\n    - SSOT（信頼できる唯一の情報源）\r\n- 値を受け渡す色々な方法\r\n    - とにかく引数に渡す！！！！\r\n        - 最もベーシックない方法！しかしこれだけでは対応できないことも…\r\n        - どういう時に、どういうふうに困るのか具体例で解説\r\n    - GO-TO系（複数コンポーネントに通知）\r\n        - Broadcast\r\n        - Event Bus\r\n    - 画面遷移時に値を渡す\r\n        - Intent・Bundle\r\n            ActivityやFragment間で使う定番。\r\n        - SavedStateHandle\r\n            ViewModelと連携し、プロセス再生成時も状態を復元できる。\r\n        - Navigation Compose\r\n            Composeでの画面遷移。Destinationの引数として値を渡しやすい。\r\n    - DIによる値受け渡し\r\n        - フィールドインジェクション\r\n        - コンストラクタインジェクション\r\n    - 状態を流すー受け取る\r\n        - StateFlow\r\n        - LiveData\r\n- それぞれの方法について、UDFは守られている？SSOTは守られている？\r\n- まとめ",
+      "i18nDesc": {
+        "ja": "Androidアプリ開発では「この値、別のクラスに渡したい！」という場面が日常茶飯事！しかし、状況や目的によって適切な方法は異なります。どのような方法があるのか、選択肢をたくさん持っていた方が、その時の状況やプロダクトの性質に合わせた最適な手段を選択できるでしょう。また、値の受け渡しに関して切っても切り離せない関係になってくるのが設計です。\n\n本セッションでは、はじめにAndroidアプリ開発における設計の原理原則に触れたあと、どのような値の受け渡し方法があり、設計観点でどのようなメリット・デメリットがあるのかを紹介します。設計に強くなって、“いい感じ”に値が渡せるアプリを作れるようになりましょう！\n\n◆ お品書き\n- とりあえずこれだけは知っておこう！設計の原理原則！！\n- UDF（単方向データフロー）\n- SSOT（信頼できる唯一の情報源）\n- 値を受け渡す色々な方法\n- とにかく引数に渡す！！！！\n- 最もベーシックない方法！しかしこれだけでは対応できないことも…\n- どういう時に、どういうふうに困るのか具体例で解説\n- GO-TO系（複数コンポーネントに通知）\n- Broadcast\n- Event Bus\n- 画面遷移時に値を渡す\n- Intent・Bundle\nActivityやFragment間で使う定番。\n- SavedStateHandle\nViewModelと連携し、プロセス再生成時も状態を復元できる。\n- Navigation Compose\nComposeでの画面遷移。Destinationの引数として値を渡しやすい。\n- DIによる値受け渡し\n- フィールドインジェクション\n- コンストラクタインジェクション\n- 状態を流すー受け取る\n- StateFlow\n- LiveData\n- それぞれの方法について、UDFは守られている？SSOTは守られている？\n- まとめ",
+        "en": "In Android app development, the thought “I need to pass this value to another class!” pops up all the time. Yet the best way to do so changes with context and goals. The more approaches you know, the better you can choose the one that fits your situation and product. And when it comes to passing values, architecture is inseparable from the discussion.\nThis session starts with the fundamental principles of Android app architecture, then surveys the many techniques for passing values and weighs their architectural pros and cons. Strengthen your design skills and build apps that pass data “just right”!\n\nAgenda\n- First things first: core architectural principles!!\n- UDF (Unidirectional Data Flow)\n- SSOT (Single Source of Truth)\n- Many ways to pass values\n- Just stick it in the parameter!!!!\n- The most basic method—yet not always enough…\n- Concrete examples of when and why it falls short\n- “GO-TO” style (notify multiple components)\n- Broadcast\n- Event Bus\n- Passing values during navigation\n- Intent / Bundle\n Standard between Activity and Fragment.\n- SavedStateHandle\n Works with ViewModel to restore state after process death.\n- Navigation Compose\n Easy to pass values as destination arguments in Compose navigation.\n- Passing values via DI\n- Field injection\n- Constructor injection\n- Stream and receive state\n- StateFlow\n- LiveData\n- For each method, does it preserve UDF? Does it honor SSOT?\n- Wrap-up\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-12T10:20:00+09:00",
+      "endsAt": "2025-09-12T11:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "ae634286-0f18-4898-9f6c-0cc2c6f645c1"
+      ],
+      "roomId": 64799,
+      "targetAudience": "- 対象レベル：初級〜中級\r\n- 設計の基本的な考え方を押さえたうえで、実務で使える“値の渡し方”をうまく選べるようになりたい方",
+      "i18nTargetAudience": {
+        "ja": "- 対象レベル：初級〜中級\n- 設計の基本的な考え方を押さえたうえで、実務で使える“値の渡し方”をうまく選べるようになりたい方",
+        "en": "- Level: Beginner to Intermediate\n- Developers who understand basic architectural concepts and want to choose effective, production-ready ways to pass values in their apps"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361164,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "3f4b4568-64b6-48e7-afc3-696d33e81827",
+      "title": {
+        "ja": "Fireside Chat",
+        "en": "Fireside Chat"
+      },
+      "description": "DroidKaigi実行委員会メンバーによるFireside Chatを開催します！\nすべての参加者にとってカンファレンスがより楽しく参加しやすい場所になるよう、私たちが日々どのような想いで活動しているのかをリラックスした雰囲気でお話しします。\n登壇者サポートや参加者同士の交流を促すための工夫など、普段はなかなか聞けない舞台裏のエピソードも交えながら、私たちのDEIに関する取り組みをご紹介します。私たちの活動を知っていただくことで、DroidKaigiやコミュニティへの参加・登壇への心理的なハードルが少しでも下がる機会となれば嬉しいです。ぜひご参加ください！",
+      "i18nDesc": {
+        "ja": "DroidKaigi実行委員会メンバーによるFireside Chatを開催します！\nすべての参加者にとってカンファレンスがより楽しく参加しやすい場所になるよう、私たちが日々どのような想いで活動しているのかをリラックスした雰囲気でお話しします。\n登壇者サポートや参加者同士の交流を促すための工夫など、普段はなかなか聞けない舞台裏のエピソードも交えながら、私たちのDEIに関する取り組みをご紹介します。私たちの活動を知っていただくことで、DroidKaigiやコミュニティへの参加・登壇への心理的なハードルが少しでも下がる機会となれば嬉しいです。ぜひご参加ください！",
+        "en": "Join us for a Fireside Chat with members of the DroidKaigi Committee!\n\nIn this relaxed, informal session, we\u0027ll share the passion and thinking that goes into our daily work to make the conference a more enjoyable and accessible place for everyone. We\u0027ll take you behind the scenes and introduce our DEI (Diversity, Equity \u0026 Inclusion) initiatives, sharing stories you don\u0027t usually get to hear about, like our speaker support program and how we encourage interaction among attendees.\n\nWe hope that with the insight of our activities, we can help reduce and hopefully eliminate any barriers to participating in or speaking at DroidKaigi and other communities. We look forward to your participation!"
+      },
+      "startsAt": "2025-09-12T15:20:00+09:00",
+      "endsAt": "2025-09-12T16:00:00+09:00",
+      "isServiceSession": true,
+      "isPlenumSession": false,
+      "speakers": [],
+      "roomId": 64803,
+      "targetAudience": "TBW",
+      "i18nTargetAudience": {
+        "ja": "TBW",
+        "en": "TBW"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361173,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": false
+      }
+    },
+    {
+      "id": "941476",
+      "title": {
+        "ja": "Androidオーディオで成功する、その先へ",
+        "en": "Android Audio: Beyond Winning On It"
+      },
+      "description": "It\u0027s 2025 and Android is still way behind iOS in terms of music and audio application ecosystems, even though audio latency is not our primary concern anymore. There are various pieces that are missing on Android and Google Play Store compared to iOS and App Store. We should catch up! In this session, let\u0027s explore how audio app ecosystem can be established on Android platforms.\r\n\r\nWinning *on* Android is not enough; we need Android as a winning party!\r\n\r\nThe aim of this session is to provide overall Android audio issues as of 2025, explore the ways to overcome current status quo, and show the roadmap towards competitive ecosystem. Then have the recording of this session to be authoritative reference for every Android audio app developer in the world.\r\n\r\nThrough this session, we will understand:\r\n\r\n- How music and audio apps work in general; what are instruments? what are DAWs? what is MIDI (and MIDI 2.0) and how do they matter (or not) ?\r\n- What is realtime audio processing, and why does it matter?\r\n- How are mobile platforms different? Why are those existing desktop solutions not enough?\r\n- What has Apple achieved on their platforms so far\r\n  - How Audio Unit v3 and Audio Workgroups work?\r\n  - How did apps like Logic Pro for iPad realize?\r\n- What is current state of union of Android audio and media APIs?\r\n  - AAudio and Oboe, MIDI API, Java API such as AudioTrack, Jetpack Media3, and DSPs (including those new in Android 16)\r\n  - music apps on Play Store\r\n- what kind of software is needed? : apps (instruments and creative apps such as DAWs), platform features, app development ecosystem (libraries), etc.\r\n",
+      "i18nDesc": {
+        "ja": "2025 年、Android はオーディオレイテンシーの改善は進んだものの、音楽やオーディオアプリケーションのエコシステムにおいて依然として iOS に大きく遅れをとっています。AndroidやGoogle Play ストアには iOS や App Store と比べて足りない部分がたくさんあります。ここで巻き返すべきでしょう！このセッションでは、Android プラットフォームでオーディオアプリのエコシステムをどう構築していくかを探っていきます。\nAndroid 上で「勝つ」だけでは不十分です。Android 自体が勝者となることが必要です！\nこのセッションの目的は、2025 年時点での Android オーディオの現状や課題を整理し、課題解決に結びつく方法を探り、競争力あるエコシステムへのロードマップを提示します。そして、この録画セッションを、世界中の Android オーディオアプリ開発者にとっての「権威あるリファレンス」にしましょう。\n本セッションを通じて以下のことを理解していきます：\n音楽・オーディオアプリのしくみ全般：インストゥルメントとは？DAW とは？MIDI（および MIDI 2.0）とは何か、そしてそれらがどのように関係しているのか？\n\nリアルタイムオーディオ処理とは何か、それがなぜ重要なのか？\n\nモバイルプラットフォームはどこが違うのか？既存のデスクトップ向けの解決策が十分でない理由は何か？\n\nApple がこれまでプラットフォーム上で達成してきたこと\n\nAudio Unit v3 や Audio Workgroups はどう機能するのか？\n\nLogic Pro for iPad向けのアプリはどう実現しているのか？\n\nAndroid のオーディオとメディア API の現状はどうなっているのか？\n\nAAudio／Oboe、MIDI API、AudioTrack をはじめとする Java API、Jetpack Media3、Android 16 で新たに導入された DSP など\n\nPlay ストア上の音楽アプリ\n\nどのようなソフトウェアが求められているのか？：アプリ（DAWのようなインストゥルメントやクリエイティブなアプリ）、プラットフォーム機能、アプリ開発エコシステム（ライブラリなど）\n\n（DroidKaigi実行委員会による翻訳）",
+        "en": "It\u0027s 2025 and Android is still way behind iOS in terms of music and audio application ecosystems, even though audio latency is not our primary concern anymore. There are various pieces that are missing on Android and Google Play Store compared to iOS and App Store. We should catch up! In this session, let\u0027s explore how audio app ecosystem can be established on Android platforms.\n\nWinning *on* Android is not enough; we need Android as a winning party!\n\nThe aim of this session is to provide overall Android audio issues as of 2025, explore the ways to overcome current status quo, and show the roadmap towards competitive ecosystem. Then have the recording of this session to be authoritative reference for every Android audio app developer in the world.\n\nThrough this session, we will understand:\n\n- How music and audio apps work in general; what are instruments? what are DAWs? what is MIDI (and MIDI 2.0) and how do they matter (or not) ?\n- What is realtime audio processing, and why does it matter?\n- How are mobile platforms different? Why are those existing desktop solutions not enough?\n- What has Apple achieved on their platforms so far\n- How Audio Unit v3 and Audio Workgroups work?\n- How did apps like Logic Pro for iPad realize?\n- What is current state of union of Android audio and media APIs?\n- AAudio and Oboe, MIDI API, Java API such as AudioTrack, Jetpack Media3, and DSPs (including those new in Android 16)\n- music apps on Play Store\n- what kind of software is needed? : apps (instruments and creative apps such as DAWs), platform features, app development ecosystem (libraries), etc."
+      },
+      "startsAt": "2025-09-11T12:20:00+09:00",
+      "endsAt": "2025-09-11T13:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "3262db6c-d659-4109-a410-2b8dac1bf737"
+      ],
+      "roomId": 64799,
+      "targetAudience": "Intermediate Android app developers who are interested in music and audio tech (almost no code / API details in the session).",
+      "i18nTargetAudience": {
+        "ja": "音楽・オーディオ技術に関心のある中級レベルの Android アプリ開発者（セッションではほとんどコードや API の詳細には踏み込みません）",
+        "en": "Intermediate Android app developers who are interested in music and audio tech (almost no code / API details in the session)."
+      },
+      "language": "ENGLISH",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361163,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": true,
+        "en": false
+      }
+    },
+    {
+      "id": "946751",
+      "title": {
+        "ja": "Cache Me If You Can",
+        "en": "Cache Me If You Can"
+      },
+      "description": "開発中に「またビルドが終わらない...」と嘆いているAndroidアプリ開発者はいませんか？\r\n\r\n近年のAndroidアプリ開発において、Gradleは依然として不可欠なビルドツールとしての地位を確立しています。\r\nしかし、Android Gradle Plugin（AGP）やKotlin Gradle Pluginは常に進化を続けており、その変更を追い続けることは多くの開発者にとって大きな負担となっています。\r\nその結果、ビルドの最適化や高速化に手が回らず、日々の開発業務において非効率を感じている方も少なくないのではないでしょうか。\r\nまた、過去の知識に基づいて記述された`build.gradle`ファイルが、現在のベストプラクティスに合致しているか自信を持てず、改善に着手できずにいるという声も聞かれます。\r\n\r\nGradleは高度なビルドプロセスを支える基盤であり、Kotlin DSLやConfiguration Cacheなどの新機能によりそのポテンシャルは高まっています。\r\n一方、Androidアプリ開発現場もマルチモジュール構成、Jetpack Compose、Kotlin Multiplatformなどの新しい技術が登場し、開発者は常に最新の知識をアップデートする必要があります。\r\n\r\n近年の開発環境において、GradleやAGPの内部動作が開発者にとって理解しにくいのは、無理からぬことでしょう。その背景には、GradleとAGPそれぞれのライフサイクルや、両者の連携に関する理解不足があります。\r\n\r\n本セッションでは、GradleとAGPに向き合ってきた経験に基づき、これらの疑問や課題に応えることを目指します。\r\n具体的には、GradleとAGPそれぞれのライフサイクルを詳細に解説し、AGPがGradleのライフサイクルにどのように統合されているのかを分かりやすく紐解きます。\r\nさらに、これらの基本的な理解を踏まえ、Gradle Build CacheやConfiguration Cacheといった強力なキャッシュ機構を最大限に活用するための具体的な設計方針、マルチモジュール構成における効率的な工夫、そして陥りがちなアンチパターンとその回避方法などを共有します。\r\nGradleのログとにらめっこする日々から卒業し、ビルド時間のストレスを削減することで、より本質的なアプリ開発に集中しましょう！\r\n\r\n予定するトーク内容\r\n■GradleとAGPのライフサイクル\r\n\r\n1. GradleとAGPそれぞれのライフサイクルの概要\r\n- Gradleの初期化フェーズ、構成フェーズ、実行フェーズの解説\r\n- AGPの初期化、同期、タスク実行といった主要なフェーズの説明\r\n- 各フェーズで何が行われているのか、APIやExtensionの活用\r\n\r\n2. ライフサイクルの理解がビルド最適化にどう繋がるか\r\n- 各ライフサイクルフェーズのボトルネックとなりやすい箇所とその原因\r\n- ライフサイクルを意識したAPIの利用法方\r\n\r\n■ビルドパフォーマンスを向上させるキャッシュ機構\r\n\r\n1. Gradle Build Cacheの仕組みと効果的な活用法\r\n- Build Cacheがどのようにビルド成果物を再利用するかのメカニズム\r\n- Build Cacheを有効にするための設定と推奨事項\r\n\r\n2. Configuration Cacheの特徴と導入時の注意点\r\n- Configuration Cacheを有効にするための要件と設定方法\r\n- 導入時に遭遇しやすい問題とその解決策\r\n\r\n3. よくあるキャッシュ無効化のアンチパターンとその回避法\r\n- 動的な依存関係の使用や不適切なタスク入力・出力定義がキャッシュに与える悪影響\r\n- キャッシュを意図せず無効化してしまうコードの例と修正方法\r\n\r\n■効率的なモジュール構成と依存関係管理\r\n\r\n1. キャッシュ効率とビルド並列化を意識したモジュール分割の考え方\r\n- 機能や責務に基づいた適切なモジュール分割の戦略\r\n- モジュール間の依存関係がビルド時間とキャッシュ効率に与える影響\r\n- 依存関係の方向性と可視性の設計における考慮事項\r\n- 大規模プロジェクトにおける効果的なモジュール管理手法\r\n- 依存関係スコープの適切な使い分け",
+      "i18nDesc": {
+        "ja": "開発中に「またビルドが終わらない...」と嘆いているAndroidアプリ開発者はいませんか？\n\n近年のAndroidアプリ開発において、Gradleは依然として不可欠なビルドツールとしての地位を確立しています。\nしかし、Android Gradle Plugin（AGP）やKotlin Gradle Pluginは常に進化を続けており、その変更を追い続けることは多くの開発者にとって大きな負担となっています。\nその結果、ビルドの最適化や高速化に手が回らず、日々の開発業務において非効率を感じている方も少なくないのではないでしょうか。\nまた、過去の知識に基づいて記述された`build.gradle`ファイルが、現在のベストプラクティスに合致しているか自信を持てず、改善に着手できずにいるという声も聞かれます。\n\nGradleは高度なビルドプロセスを支える基盤であり、Kotlin DSLやConfiguration Cacheなどの新機能によりそのポテンシャルは高まっています。\n一方、Androidアプリ開発現場もマルチモジュール構成、Jetpack Compose、Kotlin Multiplatformなどの新しい技術が登場し、開発者は常に最新の知識をアップデートする必要があります。\n\n近年の開発環境において、GradleやAGPの内部動作が開発者にとって理解しにくいのは、無理からぬことでしょう。その背景には、GradleとAGPそれぞれのライフサイクルや、両者の連携に関する理解不足があります。\n\n本セッションでは、GradleとAGPに向き合ってきた経験に基づき、これらの疑問や課題に応えることを目指します。\n具体的には、GradleとAGPそれぞれのライフサイクルを詳細に解説し、AGPがGradleのライフサイクルにどのように統合されているのかを分かりやすく紐解きます。\nさらに、これらの基本的な理解を踏まえ、Gradle Build CacheやConfiguration Cacheといった強力なキャッシュ機構を最大限に活用するための具体的な設計方針、マルチモジュール構成における効率的な工夫、そして陥りがちなアンチパターンとその回避方法などを共有します。\nGradleのログとにらめっこする日々から卒業し、ビルド時間のストレスを削減することで、より本質的なアプリ開発に集中しましょう！\n\n予定するトーク内容\n■GradleとAGPのライフサイクル\n\n1. GradleとAGPそれぞれのライフサイクルの概要\n- Gradleの初期化フェーズ、構成フェーズ、実行フェーズの解説\n- AGPの初期化、同期、タスク実行といった主要なフェーズの説明\n- 各フェーズで何が行われているのか、APIやExtensionの活用\n\n2. ライフサイクルの理解がビルド最適化にどう繋がるか\n- 各ライフサイクルフェーズのボトルネックとなりやすい箇所とその原因\n- ライフサイクルを意識したAPIの利用法方\n\n■ビルドパフォーマンスを向上させるキャッシュ機構\n\n1. Gradle Build Cacheの仕組みと効果的な活用法\n- Build Cacheがどのようにビルド成果物を再利用するかのメカニズム\n- Build Cacheを有効にするための設定と推奨事項\n\n2. Configuration Cacheの特徴と導入時の注意点\n- Configuration Cacheを有効にするための要件と設定方法\n- 導入時に遭遇しやすい問題とその解決策\n\n3. よくあるキャッシュ無効化のアンチパターンとその回避法\n- 動的な依存関係の使用や不適切なタスク入力・出力定義がキャッシュに与える悪影響\n- キャッシュを意図せず無効化してしまうコードの例と修正方法\n\n■効率的なモジュール構成と依存関係管理\n\n1. キャッシュ効率とビルド並列化を意識したモジュール分割の考え方\n- 機能や責務に基づいた適切なモジュール分割の戦略\n- モジュール間の依存関係がビルド時間とキャッシュ効率に与える影響\n- 依存関係の方向性と可視性の設計における考慮事項\n- 大規模プロジェクトにおける効果的なモジュール管理手法\n- 依存関係スコープの適切な使い分け",
+        "en": "Are there any Android app developers who find themselves sighing, “The build is taking forever…” during development?\n\nIn modern Android app development, Gradle continues to hold its place as an indispensable build tool.\nYet the Android Gradle Plugin (AGP) and Kotlin Gradle Plugin are constantly evolving, and keeping up with their changes can be a heavy burden for many developers. As a result, some teams struggle to allocate time for build optimization and acceleration, leading to inefficiencies in day-to-day development. We also hear concerns that `build.gradle` files written with outdated knowledge may no longer align with current best practices, leaving developers hesitant to refactor them.\n\nGradle forms the foundation of sophisticated build processes, and new features such as the Kotlin DSL and Configuration Cache have further unlocked its potential. At the same time, Android development has welcomed innovations like multi-module architectures, Jetpack Compose, and Kotlin Multiplatform, requiring developers to keep their knowledge continuously up-to-date.\n\nGiven today’s environment, it is understandable that the internal workings of Gradle and AGP feel opaque. This stems from an incomplete grasp of each tool’s life cycle and how the two integrate.\n\nBased on firsthand experience wrestling with Gradle and AGP, this session aims to answer those questions and challenges.\nSpecifically, we will go over the life cycles of Gradle and AGP in detail and clarify how AGP integrates into Gradle’s life cycle.\nBuilding on that foundation, we will share concrete design guidelines for fully leveraging powerful caching mechanisms such as the Gradle Build Cache and Configuration Cache, introduce efficiency techniques for multi-module projects, and highlight common anti-patterns along with ways to avoid them.\nLet’s graduate from blankly staring at Gradle logs, cut down build-time stress, and focus on what truly matters: developing great apps!\n\nPlanned Talk Content\nGradle \u0026 AGP Life Cycles\n1. Overview of each life cycle\n- Gradle’s initialization, configuration, and execution phases\n- AGP’s initialization, sync, and task-execution phases\n- What happens in each phase and how to use APIs and extensions\n\n2. How understanding the life cycle leads to optimization\n- Typical bottlenecks in each phase and their causes\n- API usage strategies that respect the life cycle\n\nCaching Mechanisms for Faster Builds\n1. Gradle Build Cache: mechanism and best practices\n- How the Build Cache reuses build outputs\n- Settings and recommendations to enable it effectively\n\n2. Configuration Cache: characteristics and adoption tips\n- Requirements and configuration to enable the cache\n- Common issues during rollout and how to solve them\n\n3. Common anti-patterns that disable caches and how to avoid them\n- Effects of dynamic dependencies and improper task input/output declarations\n- Code examples that unintentionally disable caching and how to fix them\n\nEfficient Module Architecture \u0026 Dependency Management\n1. Module partitioning with cache efficiency and parallelism in mind\n- Strategies for dividing modules by feature or responsibility\n- How inter-module dependencies impact build time and cache efficiency\n- Design considerations for dependency direction and visibility\n- Effective module management techniques in large projects\n- Proper use of dependency scopes\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-12T16:20:00+09:00",
+      "endsAt": "2025-09-12T17:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "8ef9d9b8-77cd-479e-bbd8-364f4f5746d0"
+      ],
+      "roomId": 64802,
+      "targetAudience": "- Gradleに苦手意識がある方\r\n- ビルド速度をより向上させたい方\r\n- Gradle, AGPのキャッチアップをしたい方\r\n- Lifecycle AwareなGradle Pluginを作りたい方",
+      "i18nTargetAudience": {
+        "ja": "- Gradleに苦手意識がある方\n- ビルド速度をより向上させたい方\n- Gradle, AGPのキャッチアップをしたい方\n- Lifecycle AwareなGradle Pluginを作りたい方",
+        "en": "- Developers who feel uneasy about Gradle\n- Anyone eager to speed up their builds\n- Those who want to catch up on the latest Gradle \u0026 AGP features\n- Developers aiming to create life-cycle-aware Gradle plugins"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361170,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "946204",
+      "title": {
+        "ja": "Be a Business-Driven Android Engineer",
+        "en": "Be a Business-Driven Android Engineer"
+      },
+      "description": "Kotlin Multiplatformの発展により、Androidエンジニアが “ビジネスを伸ばす当事者” になるチャンスが急拡大しています。本セッションでは、1.  年間売上600億円規模の食品ECプロダクトを開発するモバイル・エンジニアリングチームが2年前に売上というKPIを背負ってから得られた失敗と、専門性を越えたアクション（越境）の重要性について共有し、2. Kotlin Multiplatformの技術選定を軸にしたAndroidエンジニア向けの越境手法と、3. 特に効果の高かった越境事例を紹介します。このセッションを通して、Androidエンジニアがビジネスに貢献するアクションを実践する勇気と事例を学ぶことができます。\r\n\r\n1. モバイルエンジニアが売上をKPIに持つことで得られた学び\r\n\r\n2年前、AndroidとiOSのネイティブアプリを開発する私たちモバイルエンジニアは、”売上” をKPIに持ちました。その後、ビジネスに貢献するエンジニアになるためにやってきた事はまるで結果に繋がりませんでした。この経験から得られた失敗と学びを共有し、エンジニアリングチームが売上KPIを持ち、経験してきた実際の事例を共有します。\r\n\r\n2. 越境しよう！\r\n\r\nビジネスへ貢献しようとすると、普段自分が抱えている領域を越えて行動する必要があります。しかし、いきなり経験のない領域に飛び込むには勇気が必要です。Kotlin Multiplatformの技術選定とそれがもたらす仕組みを例に、越境しやすい領域を紹介します。\r\n\r\nKotlin Multiplatformは、現在Androidアプリ開発を行っているチームの越境をデザインする最も良い選択肢です。私たちのチームはKotlin Multiplatformの技術選択によって、AndroidとiOSの越境にチャレンジしやすい環境を設計することができました。この事例を軸に、私たちが行ってきた様々な越境を紹介します。Androidアプリ開発の周辺には、iOSやWeb、バックエンドなどのソフトウェアエンジニアリング領域に留まらず、デザインやデータ分析、マーケティング、そして採用や育成など多くの専門性が隣接しています。それらを越境の選択肢と捉え、今までのキャリアや指向を照らし合わせることで、自分なりのビジネスへの貢献方法に気づくきっかけが得られるはずです。\r\n\r\n3. 効果の高かった越境事例\r\n\r\n2年間のチャレンジを通して、私たちモバイルエンジニアはビジネスに貢献できたのでしょうか？定量的な具体例と共に、特に効果の高かった越境事例を解説し、モバイルエンジニアが自律的にビジネスに貢献するアクションを深掘りします。\r\n- 顧客行動データ分析\r\n- 顧客体験設計\r\n- iOSアプリ開発",
+      "i18nDesc": {
+        "ja": "Kotlin Multiplatformの発展により、Androidエンジニアが “ビジネスを伸ばす当事者” になるチャンスが急拡大しています。本セッションでは、1. 年間売上600億円規模の食品ECプロダクトを開発するモバイル・エンジニアリングチームが2年前に売上というKPIを背負ってから得られた失敗と、専門性を越えたアクション（越境）の重要性について共有し、2. Kotlin Multiplatformの技術選定を軸にしたAndroidエンジニア向けの越境手法と、3. 特に効果の高かった越境事例を紹介します。このセッションを通して、Androidエンジニアがビジネスに貢献するアクションを実践する勇気と事例を学ぶことができます。\n\n1. モバイルエンジニアが売上をKPIに持つことで得られた学び\n\n2年前、AndroidとiOSのネイティブアプリを開発する私たちモバイルエンジニアは、”売上” をKPIに持ちました。その後、ビジネスに貢献するエンジニアになるためにやってきた事はまるで結果に繋がりませんでした。この経験から得られた失敗と学びを共有し、エンジニアリングチームが売上KPIを持ち、経験してきた実際の事例を共有します。\n\n2. 越境しよう！\n\nビジネスへ貢献しようとすると、普段自分が抱えている領域を越えて行動する必要があります。しかし、いきなり経験のない領域に飛び込むには勇気が必要です。Kotlin Multiplatformの技術選定とそれがもたらす仕組みを例に、越境しやすい領域を紹介します。\n\nKotlin Multiplatformは、現在Androidアプリ開発を行っているチームの越境をデザインする最も良い選択肢です。私たちのチームはKotlin Multiplatformの技術選択によって、AndroidとiOSの越境にチャレンジしやすい環境を設計することができました。この事例を軸に、私たちが行ってきた様々な越境を紹介します。Androidアプリ開発の周辺には、iOSやWeb、バックエンドなどのソフトウェアエンジニアリング領域に留まらず、デザインやデータ分析、マーケティング、そして採用や育成など多くの専門性が隣接しています。それらを越境の選択肢と捉え、今までのキャリアや指向を照らし合わせることで、自分なりのビジネスへの貢献方法に気づくきっかけが得られるはずです。\n\n3. 効果の高かった越境事例\n\n2年間のチャレンジを通して、私たちモバイルエンジニアはビジネスに貢献できたのでしょうか？定量的な具体例と共に、特に効果の高かった越境事例を解説し、モバイルエンジニアが自律的にビジネスに貢献するアクションを深掘りします。\n- 顧客行動データ分析\n- 顧客体験設計\n- iOSアプリ開発",
+        "en": "With the rise of Kotlin Multiplatform, Android engineers now have an unprecedented chance to become true drivers of business growth. This session will:\n1. Share the hard-won lessons and the importance of cross-disciplinary action (“border-crossing”) learned after a mobile engineering team developing a food e-commerce product with annual sales of ¥60 billion took on “revenue” as its KPI two years ago.\n2. Present practical border-crossing approaches for Android engineers, centered on the technical choice of Kotlin Multiplatform.\n3. Highlight the most impactful border-crossing cases we encountered.\nThrough these stories you will gain both the courage and the concrete examples needed to take business-oriented action as an Android engineer.\n\n1. What we learned by setting “revenue” as our KPI\n\nTwo years ago our mobile engineers, who build native Android and iOS apps, set “revenue” as their KPI. Many of our early efforts produced no measurable results. We will share those failures, what we learned, and real-world cases of an engineering team carrying a revenue KPI.\n\n2. Let’s cross borders!\n\nContributing to the business means acting beyond your usual domain, which can feel daunting.Using our adoption of Kotlin Multiplatform as an example, we will map out domains that are easier to cross into.\n\nKotlin Multiplatform is the optimal choice for designing cross-disciplinary collaboration for teams currently developing Android apps. By selecting Kotlin Multiplatform, our team created an environment that makes it easy to tackle cross-platform challenges between Android and iOS. Centering on this case study, we will showcase the diverse forms of cross-boundary work we have undertaken. Surrounding Android app development are adjacent fields not only in software engineering—such as iOS, web, and backend—but also in design, data analysis, marketing, and even hiring and training, each demanding its own expertise. By treating these as options for stepping beyond one’s usual domain and aligning them with your career background and interests, you can uncover new ways to contribute to the business in your own unique style.\n\n3. Border-crossing cases that were effective\n\nOver the course of our two-year challenge, were we mobile engineers able to contribute to the business? With quantitative, concrete examples, we will explain the most impactful cross-disciplinary cases and delve into actions that mobile engineers can autonomously take to drive business value.\n- Customer-behavior data analysis\n- Customer-experience design\n- iOS app development\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-12T17:20:00+09:00",
+      "endsAt": "2025-09-12T18:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "03f7318b-847b-4b2f-b016-6c9c0b3c4062"
+      ],
+      "roomId": 64801,
+      "targetAudience": "Kotlin Multiplatformを利用している・検討しているAndroidエンジニアやテックリード、マネージャーの方\r\nエンジニアリングを活かしてビジネスに貢献する事に悩んでいる方",
+      "i18nTargetAudience": {
+        "ja": "Kotlin Multiplatformを利用している・検討しているAndroidエンジニアやテックリード、マネージャーの方\nエンジニアリングを活かしてビジネスに貢献する事に悩んでいる方",
+        "en": "Android engineers, tech leads, and managers who are using or considering Kotlin Multiplatform\nAnyone wrestling with how to leverage engineering skills to drive business results"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361172,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "936837",
+      "title": {
+        "ja": "UIだけじゃないComposeの可能性 ━ 宣言的に奏でるメロディ",
+        "en": "Compose Beyond UI — Crafting Melodies Declaratively"
+      },
+      "description": "ComposeはUIフレームワークとして広く使われるようになりましたが、その仕組みはUI以外にも応用可能であることはご存知でしょうか。\r\n\r\nComposeを構成するモジュールのうち最も低レイヤーに位置するRuntimeは、UI構築に限らず汎用的に利用できる設計になっています。しかし、普段のUI開発ではRuntimeのAPIの一部分しか利用しないため、全容はあまり知られていません。\r\n\r\nRuntimeは、コードを宣言的に記述し実行するための基盤となるAPIを提供しており、Composeの宣言的なプログラミングを支えています。Runtimeの仕組みを理解して活用することで、Composeの宣言的なプログラミング手法を独自の処理に適用できます。\r\n\r\nこのセッションでは、普段は意識することなく利用しているRuntimeにスポットを当て、活用例を紹介します。ComposeにおけるRuntimeの役割を解説し、独自の処理への適用方法を紹介します。そして、UI構築にとどまらないRuntimeの活用方法の一例として、コードで表現したメロディや音声効果をそのまま再生する「宣言的音声処理」という独自の試みを、デモを交えて紹介します。\r\n\r\nこのセッションを通してComposeの仕組みを理解し、UI以外にも応用可能な宣言的プログラミングの視点を得ることができます。Composeの大きな可能性を感じてください。",
+      "i18nDesc": {
+        "ja": "ComposeはUIフレームワークとして広く使われるようになりましたが、その仕組みはUI以外にも応用可能であることはご存知でしょうか。\n\nComposeを構成するモジュールのうち最も低レイヤーに位置するRuntimeは、UI構築に限らず汎用的に利用できる設計になっています。しかし、普段のUI開発ではRuntimeのAPIの一部分しか利用しないため、全容はあまり知られていません。\n\nRuntimeは、コードを宣言的に記述し実行するための基盤となるAPIを提供しており、Composeの宣言的なプログラミングを支えています。Runtimeの仕組みを理解して活用することで、Composeの宣言的なプログラミング手法を独自の処理に適用できます。\n\nこのセッションでは、普段は意識することなく利用しているRuntimeにスポットを当て、活用例を紹介します。ComposeにおけるRuntimeの役割を解説し、独自の処理への適用方法を紹介します。そして、UI構築にとどまらないRuntimeの活用方法の一例として、コードで表現したメロディや音声効果をそのまま再生する「宣言的音声処理」という独自の試みを、デモを交えて紹介します。\n\nこのセッションを通してComposeの仕組みを理解し、UI以外にも応用可能な宣言的プログラミングの視点を得ることができます。Composeの大きな可能性を感じてください。",
+        "en": "Compose has become widely adopted as a UI framework, but did you know that its mechanisms can be applied beyond UI as well?\n\nAmong the modules that make up Compose, the lowest-level layer—Runtime—is designed for general-purpose use, not just building UIs. Yet, everyday UI development touches only a subset of its APIs, so its full capabilities remain largely not known.\n\nRuntime provides foundational APIs that let you write and execute code declaratively, underpinning Compose’s declarative programming style. By understanding and leveraging Runtime, you can apply Compose’s declarative approach to your own logic.\n\nThis session shines a spotlight on the Runtime you normally use unconsciously and showcases practical examples. We will explain Runtime’s role inside Compose and demonstrate how to adapt it to your own processes. As an example of Runtime applied beyond UI, you’ll be presented a demo of “declarative audio processing,” which plays melodies and sound effects directly from declarative code.\n\nThrough this session, you will gain insight into Compose’s inner workings and acquire a perspective on declarative programming that extends beyond UI. Experience the vast possibilities of Compose.\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-11T12:20:00+09:00",
+      "endsAt": "2025-09-11T13:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "0dece370-29a7-4e3c-a56d-83350b23c2dc"
+      ],
+      "roomId": 64800,
+      "targetAudience": "- Compose中級者以上\r\n- Composeをより深く理解したい人\r\n- Composeで何か面白いことをやってみたい人",
+      "i18nTargetAudience": {
+        "ja": "- Compose中級者以上\n- Composeをより深く理解したい人\n- Composeで何か面白いことをやってみたい人",
+        "en": "- Intermediate-level Compose developers and above\n- Those who want to understand Compose more deeply\n- Those who want to do something fun with Compose"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361169,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "946631",
+      "title": {
+        "ja": "Androidは裏でどのようにデータ構造を活用しているのか",
+        "en": "How Android Uses Data Structures Behind the Scenes"
+      },
+      "description": "Whether you graduated with a computer science degree or studied data structures while preparing for developer interviews, you’ve likely encountered concepts like LinkedList, Disjoint Set, B-Tree, and Red-Black Tree at least once. \r\nBut have you ever considered actually applying these data structure concepts when building real Android apps? In fact, these data structures are often used behind the scenes in the Android framework and its libraries—even though you may never need to interact with them directly. In this presentation, we’ll explore how data structure knowledge is employed within the Android framework and key libraries, and explain why it’s important for us to understand these concepts.\r\n\r\nIntroduction: Have you ever leveraged knowledge of data structures when developing Android applications?\r\n  - If so, are the data structures we learn actually used in real Android development?\r\n1. The Layout Tree (Composable Tree) for rendering the screen\r\n  - About the Tree data structure\r\n  - Why the Tree was the inevitable choice—considering traversal time complexity (efficiency)\r\n    - Based on this, how is the screen rendered and updated efficiently?\r\n2. Dependency Injection Tools (Graph/Directed Acyclic Graph)\r\n  - About the Directed Acyclic Graph data structure\r\n  - Why Dagger chooses a graph data structure for dependency injection\r\n  - How to detect and resolve circular dependencies using this data structure\r\nConclusion: Data structure knowledge is being used in ways you might not realize\r\n\r\nIf time allows:\r\n3. The Handler mechanism for processing Runnables\r\n  - About Priority Queues\r\n  - Why priority queues are an efficient choice\r\n4. Image caching (LruCache)",
+      "i18nDesc": {
+        "ja": "コンピュータサイエンスの学位を取得したにせよ、技術面接の準備でデータ構造を学んだにせよ、LinkedList、Disjoint Set、B-Tree、Red-Black Treeといった概念は誰もが一度は触れたことがあるでしょう。\nしかし、実際のAndroidアプリ開発においてこれらのデータ構造を活用することを考えたことはありますか？実はAndroidフレームワークやそのライブラリの内部では、たとえ私たちが直接扱うことがなくてもこうしたデータ構造が頻繁に使われているのです。本セッションでは、Androidフレームワークと主要ライブラリにおいてデータ構造の知識がどのように活かされているかを紐解き、その理解がなぜ重要なのかを解説します。\n導入：Androidアプリ開発において、データ構造の知識を活用したことはありますか？\n- もしあるなら、私たちが学んだデータ構造は実際のAndroid開発で本当に使われているのでしょうか？\n1. 画面描画のためのLayout Tree（Composable Tree）\n- ツリー型データ構造について\n- なぜツリーが必然的な選択だったのか：走査の計算量（効率性）を考慮して\n- これをもとに、画面はどのように効率的に描画・更新されているのか？\n2. DIツール（グラフ／有向非巡回グラフ）\n- 有向非巡回グラフ（DAG）データ構造について\n- Daggerが依存性注入にグラフ構造を選んでいる理由\n- このデータ構造を用いて循環依存をどのように検出・解消するか\n終わりに： データ構造の知識は、私たちが気づかないうちに活用されている\n時間が許せば：\n3. Runnableを処理するためのHandlerメカニズム\n- 優先度付きキューについて\n- なぜ優先度付きキューが効率的な選択なのか？\n4. 画像キャッシュ（LruCache）\n\n（DroidKaigi実行委員会による翻訳）",
+        "en": "Whether you graduated with a computer science degree or studied data structures while preparing for developer interviews, you’ve likely encountered concepts like LinkedList, Disjoint Set, B-Tree, and Red-Black Tree at least once.\nBut have you ever considered actually applying these data structure concepts when building real Android apps? In fact, these data structures are often used behind the scenes in the Android framework and its libraries—even though you may never need to interact with them directly. In this presentation, we’ll explore how data structure knowledge is employed within the Android framework and key libraries, and explain why it’s important for us to understand these concepts.\n\nIntroduction: Have you ever leveraged knowledge of data structures when developing Android applications?\n- If so, are the data structures we learn actually used in real Android development?\n1. The Layout Tree (Composable Tree) for rendering the screen\n- About the Tree data structure\n- Why the Tree was the inevitable choice—considering traversal time complexity (efficiency)\n- Based on this, how is the screen rendered and updated efficiently?\n2. Dependency Injection Tools (Graph/Directed Acyclic Graph)\n- About the Directed Acyclic Graph data structure\n- Why Dagger chooses a graph data structure for dependency injection\n- How to detect and resolve circular dependencies using this data structure\nConclusion: Data structure knowledge is being used in ways you might not realize\n\nIf time allows:\n3. The Handler mechanism for processing Runnables\n- About Priority Queues\n- Why priority queues are an efficient choice\n4. Image caching (LruCache)"
+      },
+      "startsAt": "2025-09-12T12:20:00+09:00",
+      "endsAt": "2025-09-12T13:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "7695ea9f-552f-49ac-881d-5e5c7b84fd2e"
+      ],
+      "roomId": 64801,
+      "targetAudience": "- People who have wondered how the Android framework and libraries work under the hood and why certain design decisions were made\r\n\r\n- Those who feel disillusioned that their computer science knowledge doesn’t seem to be applied in their development work or are curious about how computer science concepts are used in Android development\r\n\r\n- Anyone interested in making informed decisions to build high-performance apps",
+      "i18nTargetAudience": {
+        "ja": "- Androidフレームワークやライブラリが内部でどのように動作しているのか、なぜそのような設計になっているのかに興味がある人\n\n- コンピュータサイエンスの知識が開発の現場で活かされていないと感じている人、またはそれがAndroid開発でどのように使われているのか知りたい人\n\n- 高パフォーマンスなアプリを構築するために、知識に基づいた意思決定をしたい人",
+        "en": "- People who have wondered how the Android framework and libraries work under the hood and why certain design decisions were made\n\n- Those who feel disillusioned that their computer science knowledge doesn’t seem to be applied in their development work or are curious about how computer science concepts are used in Android development\n\n- Anyone interested in making informed decisions to build high-performance apps"
+      },
+      "language": "ENGLISH",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361167,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": true,
+        "en": false
+      }
+    },
+    {
+      "id": "946771",
+      "title": {
+        "ja": "Navigation 2 を 3 に移行する（予定）ためにやったこと",
+        "en": "What We’ve Done to (Plan to) Migrate from Navigation 2 to 3"
+      },
+      "description": "Jetpack Navigation 3 は、Google I/O 2025 にて発表された、Jetpack Compose 専用に再設計された新しいナビゲーションライブラリです。従来の Navigation 2（navigation-compose）と比べて構造が大きく見直されており、Compose の状態管理とより自然に連携できる設計が特徴です。\r\n\r\n代表的な変更点としては、NavHost の構成が Scene ベースに変わったこと、BackStack を MutableList で直接扱えるようになったこと、状態保持が Compose の仕組みとより自然に連携できるようになったことなどが挙げられます。これにより、戻る操作や履歴の制御が柔軟になる一方で、既存のコード構成との違いを丁寧に把握する必要があります。\r\n\r\nこうした背景を受けて、現在 navigation-compose を用いて運用している弊社のアプリ「ワンバンク」でも、Navigation 3 への移行を予定しており、そのための調査や準備を進めています。\r\n\r\n本セッションでは、以下のような観点で進めている対応内容を紹介します：\r\n- Navigation 3 の公式ドキュメントおよびサンプルコードをもとにした新 API の構造理解\r\n- 弊社アプリにおけるナビゲーショングラフや遷移パターンの棚卸し\r\n- Navigation 3 の構造や責務の違いが既存コードに与える影響の整理\r\n- 小規模な Compose 画面での移行実装と、画面遷移・戻る操作などの基本的な挙動の検証\r\n- Deep Link の扱いや、複数画面の状態保持に関する検討ポイントの整理\r\n\r\nNavigation 3 を前提に設計されたアプリが今後増えていく中で、Navigation 2 を運用している既存プロジェクトが、どう段階的に移行していくかを考える際の参考になればと思います。",
+      "i18nDesc": {
+        "ja": "Jetpack Navigation 3 は、Google I/O 2025 にて発表された、Jetpack Compose 専用に再設計された新しいナビゲーションライブラリです。従来の Navigation 2（navigation-compose）と比べて構造が大きく見直されており、Compose の状態管理とより自然に連携できる設計が特徴です。\n\n代表的な変更点としては、NavHost の構成が Scene ベースに変わったこと、BackStack を MutableList で直接扱えるようになったこと、状態保持が Compose の仕組みとより自然に連携できるようになったことなどが挙げられます。これにより、戻る操作や履歴の制御が柔軟になる一方で、既存のコード構成との違いを丁寧に把握する必要があります。\n\nこうした背景を受けて、現在 navigation-compose を用いて運用している弊社のアプリ「ワンバンク」でも、Navigation 3 への移行を予定しており、そのための調査や準備を進めています。\n\n本セッションでは、以下のような観点で進めている対応内容を紹介します：\n- Navigation 3 の公式ドキュメントおよびサンプルコードをもとにした新 API の構造理解\n- 弊社アプリにおけるナビゲーショングラフや遷移パターンの棚卸し\n- Navigation 3 の構造や責務の違いが既存コードに与える影響の整理\n- 小規模な Compose 画面での移行実装と、画面遷移・戻る操作などの基本的な挙動の検証\n- Deep Link の扱いや、複数画面の状態保持に関する検討ポイントの整理\n\nNavigation 3 を前提に設計されたアプリが今後増えていく中で、Navigation 2 を運用している既存プロジェクトが、どう段階的に移行していくかを考える際の参考になればと思います。",
+        "en": "Jetpack Navigation 3 is a new navigation library, completely redesigned for Jetpack Compose and announced at Google I/O 2025. Compared with the previous Navigation 2 (navigation-compose), its structure has been significantly revised so that it works more naturally with Compose’s state management.\n\nKey changes include a scene-based NavHost structure, direct access to the BackStack via a MutableList, and state retention that ties in more seamlessly with Compose mechanisms. These improvements make back-navigation and history control more flexible, but they also require a careful understanding of how Navigation 3 differs from existing codebases.\n\nWith this in mind, we’re planning to migrate our company’s app “OneBank,” which currently uses navigation-compose, to Navigation 3, and we’ve begun research and preparations.\n\nThis session introduces the work we’re doing from the following perspectives:\n- Understanding the new API architecture through the official Navigation 3 documentation and sample code\n- Taking stock of our app’s navigation graph and transition patterns\n- Mapping out how Navigation 3’s structure and responsibilities affect existing code\n- Implementing a small-scale migration on individual Compose screens and verifying basic behaviors such as screen transitions and back navigation\n- Organizing discussion points on Deep Link handling and state retention across multiple screens\n\nAs apps designed around Navigation 3 become more common, we hope these insights will help projects currently on Navigation 2 migrate in a phased and manageable way.\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-12T11:20:00+09:00",
+      "endsAt": "2025-09-12T12:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "8bb04227-122b-4bf8-838d-effb920fbf59"
+      ],
+      "roomId": 64802,
+      "targetAudience": "- Jetpack Compose を使ったアプリ開発を行っており、ナビゲーションの構成や設計を見直したいと考えている方\r\n- Navigation 2（navigation-compose）を利用していて、Navigation 3 との違いや移行のポイントを把握しておきたい方\r\n- 今後のプロジェクトで Navigation 3 を活用する可能性があり、基本的な考え方や導入の流れを知っておきたい方",
+      "i18nTargetAudience": {
+        "ja": "- Jetpack Compose を使ったアプリ開発を行っており、ナビゲーションの構成や設計を見直したいと考えている方\n- Navigation 2（navigation-compose）を利用していて、Navigation 3 との違いや移行のポイントを把握しておきたい方\n- 今後のプロジェクトで Navigation 3 を活用する可能性があり、基本的な考え方や導入の流れを知っておきたい方",
+        "en": "- Developers building apps with Jetpack Compose who want to review and refine their navigation architecture\n- Teams using Navigation 2 (navigation-compose) who want to understand the differences with Navigation 3 and the key points for migration\n- Those who may adopt Navigation 3 in future projects and wish to grasp its core concepts and ways to migrate"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361168,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "989391",
+      "title": {
+        "ja": "KotlinでのAI活用による開発",
+        "en": "Building with AI in Kotlin"
+      },
+      "description": "AI provides great new opportunities for both developers and for users. In the first part of this session, we’ll take a look at how you as Kotlin engineers can get the most out of AI-enhanced tooling and coding agents in your day-to-day work. From navigating a new codebase to implementing new features faster, AI tools can help you every step of the way.\r\nIn the second part of this session, we’ll see how you can enhance your own applications with AI capabilities, including the ability to create complex agentic workflows. We will also see the Koog framework built by JetBrains in action, which is designed to build agents in idiomatic Kotlin.\r\n\r\n",
+      "i18nDesc": {
+        "ja": "AIは開発者にもユーザーにも大きな新たな可能性をもたらします。本セッションの前半では、Kotlinエンジニアとして、日々の開発業務においてAIを活用したツールやコーディングエージェントを最大限に活用する方法をご紹介します。新しいコードベースの理解から、新機能の高速実装まで、AIツールがあなたの開発をあらゆる段階で支援します。\nセッション後半では、AI機能を自分のアプリケーションに組み込む方法を、複雑なエージェントワークフローを構築する能力も含めて見ていきます。また『Koog』という、JetBrainsが開発したKotlinらしいコードでエージェントを構成できるフレームワークを紹介します。\n\n（DroidKaigi実行委員会による翻訳）",
+        "en": "AI provides great new opportunities for both developers and for users. In the first part of this session, we’ll take a look at how you as Kotlin engineers can get the most out of AI-enhanced tooling and coding agents in your day-to-day work. From navigating a new codebase to implementing new features faster, AI tools can help you every step of the way.\nIn the second part of this session, we’ll see how you can enhance your own applications with AI capabilities, including the ability to create complex agentic workflows. We will also see the Koog framework built by JetBrains in action, which is designed to build agents in idiomatic Kotlin."
+      },
+      "startsAt": "2025-09-11T11:20:00+09:00",
+      "endsAt": "2025-09-11T12:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "a82c6942-6e2b-4d80-9883-0b84b932d6ef",
+        "5307510b-c3fa-4f9c-a340-36d198198ef5"
+      ],
+      "roomId": 64801,
+      "targetAudience": "TBW",
+      "i18nTargetAudience": {
+        "ja": "TBW",
+        "en": "TBW"
+      },
+      "language": "ENGLISH",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361173,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": true,
+        "en": false
+      }
+    },
+    {
+      "id": "941133",
+      "title": {
+        "ja": "Metro で学ぶ依存性注入のナビゲーション",
+        "en": "Navigating Dependency Injection with Metro"
+      },
+      "description": "Metro is yet another compile-time dependency injection framework. How is this one different though? In this talk we’ll explore how it balances blazing-fast compile times without sacrificing features, deep dive into how it works under the hood, and how to start using it seamlessly in your existing projects. From compiler plugins to graph theory to multiplatform, this talk will cover a bit of everything!",
+      "i18nDesc": {
+        "ja": "Metro は、また新たなコンパイル時依存性注入(compile-time Dependency Injection)フレームワークです。では、他と何が違うのでしょうか？\nこのセッションでは、機能性を犠牲にせずに驚くほど短いコンパイル時間を実現する方法や、内部の仕組みを深掘りし、既存のプロジェクトにシームレスに導入する方法を紹介します。\nコンパイラーのプラグインからグラフ理論、マルチプラットフォーム対応まで、あらゆる要素をカバーしていきます！\n\n（DroidKaigi実行委員会による翻訳）",
+        "en": "Metro is yet another compile-time dependency injection framework. How is this one different though? In this talk we’ll explore how it balances blazing-fast compile times without sacrificing features, deep dive into how it works under the hood, and how to start using it seamlessly in your existing projects. From compiler plugins to graph theory to multiplatform, this talk will cover a bit of everything!"
+      },
+      "startsAt": "2025-09-12T14:20:00+09:00",
+      "endsAt": "2025-09-12T15:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "8ce6cf3a-735e-4a2a-b05f-e2081e5b6741"
+      ],
+      "roomId": 64800,
+      "targetAudience": "This is going to be intermediate level. It will have some introduction of DI concepts for those that haven’t used any DI framework before, but it will be a more valuable talk to those with prior experience with DI frameworks like Dagger/kotlin-inject/Guice.",
+      "i18nTargetAudience": {
+        "ja": "このトークは中級者向けです。DI（依存性注入）フレームワークを使ったことがない人向けに基本的な概念の紹介も行いますが、Dagger、kotlin-inject、Guice などのフレームワークの経験がある方にとってより価値のある内容となっています。",
+        "en": "This is going to be intermediate level. It will have some introduction of DI concepts for those that haven’t used any DI framework before, but it will be a more valuable talk to those with prior experience with DI frameworks like Dagger/kotlin-inject/Guice."
+      },
+      "language": "ENGLISH",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361159,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": true,
+        "en": false
+      }
+    },
+    {
+      "id": "946618",
+      "title": {
+        "ja": "Androidライブラリアンの手引き：堅牢なライブラリとSDKの構築",
+        "en": "Android Librarian\u0027s Guide: Building Robust Libraries and SDKs"
+      },
+      "description": "In this talk, the speaker (skydoves) shares real-world lessons from maintaining Android open-source libraries and SDKs, including his work on the RevenueCat SDK. You\u0027ll learn what it takes to build robust, well-maintained libraries/SDKs that scale across teams and products.\r\n\r\nTopics include:\r\n\r\n* The importance of stable and intentional public API surfaces\r\n* Strategies for API lifecycle: design, development, versioning, and release (Exposing Android resources, binary compatibilities, etc)\r\n* Managing Android transitive dependencies and understanding the impact of the R class\r\n* Increase libraries/SDKs performance using Baseline Profiles\r\n* Writing effective documentation that supports adoption\r\n* Developer marketing strategies (time permitting)",
+      "i18nDesc": {
+        "ja": "このセッションでは、スピーカー（skydoves）が、RevenueCat SDKを含むAndroidのオープンソースライブラリやSDKの保守経験から得た実際の教訓を共有します。チームや製品を超えてスケールする、堅牢でメンテナンスしやすいライブラリやSDKを構築するために必要なことを学べます。\n\n主な内容：\n* 安定した意図的なパブリックAPI設計の重要性\n* APIライフサイクルの戦略：設計、開発、バージョニング、リリース（Androidリソースの公開、バイナリ互換性など）\n* Androidの推移的依存関係の管理とRクラスが及ぼす影響の理解\n* Baseline Profilesを活用したライブラリやSDKのパフォーマンス向上\n* 採用を促進するための効果的なドキュメントの書き方\n* デベロッパー向けマーケティング戦略（時間があれば）\n\n（DroidKaigi実行委員会による翻訳）",
+        "en": "In this talk, the speaker (skydoves) shares real-world lessons from maintaining Android open-source libraries and SDKs, including his work on the RevenueCat SDK. You\u0027ll learn what it takes to build robust, well-maintained libraries/SDKs that scale across teams and products.\n\nTopics include:\n\n* The importance of stable and intentional public API surfaces\n* Strategies for API lifecycle: design, development, versioning, and release (Exposing Android resources, binary compatibilities, etc)\n* Managing Android transitive dependencies and understanding the impact of the R class\n* Increase libraries/SDKs performance using Baseline Profiles\n* Writing effective documentation that supports adoption\n* Developer marketing strategies (time permitting)"
+      },
+      "startsAt": "2025-09-11T15:20:00+09:00",
+      "endsAt": "2025-09-11T16:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "ce796919-a8d8-438e-a0b6-900ac554f98e"
+      ],
+      "roomId": 64801,
+      "targetAudience": "This talk is for Android developers who are not only interested in building open-source libraries or SDKs, but also those who use them regularly and want to better understand the internal foundations behind them.",
+      "i18nTargetAudience": {
+        "ja": "このセッションは、オープンソースライブラリやSDKの構築に興味があるAndroid開発者だけでなく、それらを日常的に使用しており、その内部的な基盤をより深く理解したいと考えている開発者にも向けられています。",
+        "en": "This talk is for Android developers who are not only interested in building open-source libraries or SDKs, but also those who use them regularly and want to better understand the internal foundations behind them."
+      },
+      "language": "ENGLISH",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361173,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": true,
+        "en": false
+      }
+    },
+    {
+      "id": "c9e0f605-d74c-484e-8fb2-334d7965c5e6",
+      "title": {
+        "ja": "Closing",
+        "en": "Closing"
+      },
+      "description": null,
+      "i18nDesc": {
+        "ja": "Closing",
+        "en": "Closing"
+      },
+      "startsAt": "2025-09-12T18:20:00+09:00",
+      "endsAt": "2025-09-12T18:40:00+09:00",
+      "isServiceSession": true,
+      "isPlenumSession": false,
+      "speakers": [],
+      "roomId": 64801,
+      "targetAudience": "TBW",
+      "i18nTargetAudience": {
+        "ja": "TBW",
+        "en": "TBW"
+      },
+      "language": "MIXED",
+      "lengthInMinutes": 20,
+      "sessionCategoryItemId": 361173,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": false
+      }
+    },
+    {
+      "id": "940148",
+      "title": {
+        "ja": "テストコードはもう書かない：JetBrains AI Assistantに委ねる非同期処理のテスト自動設計・生成",
+        "en": "No More Writing Test Code: Automated Design and Generation of Asynchronous Tests Delegated to JetBrains AI Assistant"
+      },
+      "description": "非同期処理を含むユニットテストの設計・記述は、Android開発において最も煩雑で属人的な工程の一つです。本セッションでは、JetBrains AI Assistantを活用し、テスト設計の発想からモックの注入、テスト実装の生成、さらには改善提案までのすべてをAIに委ねてみるアプローチにより、開発速度やテストカバレッジの向上、コードの一貫性の担保などに役立つか検証します。\r\n\r\n対象は、Roomによる永続化処理と、WorkManagerによる非同期バックグラウンド処理。エンジニアは仕様とゴールのみを指示し、テストの意図、前提、データ設計、アサーション設計をAIが担う構成です。\r\n\r\nAIはもはや「補助者」ではなく、「自律型テスト設計者」となれるのか？ という問いに、実演と失敗の検証をもとに答えていきます。\r\n\r\n構成\r\n1. テスト作成の課題\r\n2. JetBrains AI Assistantのコンセプトと設定方法\r\n3. 実践①：RoomのDAOテストをAIに依頼\r\n4. 実践②：WorkManagerのテスト設計をAIに依頼\r\n5. AI設計の限界と回避策\r\n6. 自律型開発補助の次なる可能性",
+      "i18nDesc": {
+        "ja": "非同期処理を含むユニットテストの設計・記述は、Android開発において最も煩雑で属人的な工程の一つです。本セッションでは、JetBrains AI Assistantを活用し、テスト設計の発想からモックの注入、テスト実装の生成、さらには改善提案までのすべてをAIに委ねてみるアプローチにより、開発速度やテストカバレッジの向上、コードの一貫性の担保などに役立つか検証します。\n\n対象は、Roomによる永続化処理と、WorkManagerによる非同期バックグラウンド処理。エンジニアは仕様とゴールのみを指示し、テストの意図、前提、データ設計、アサーション設計をAIが担う構成です。\n\nAIはもはや「補助者」ではなく、「自律型テスト設計者」となれるのか？ という問いに、実演と失敗の検証をもとに答えていきます。\n\n構成\n1. テスト作成の課題\n2. JetBrains AI Assistantのコンセプトと設定方法\n3. 実践①：RoomのDAOテストをAIに依頼\n4. 実践②：WorkManagerのテスト設計をAIに依頼\n5. AI設計の限界と回避策\n6. 自律型開発補助の次なる可能性",
+        "en": "Designing and writing unit tests that involve asynchronous operations is one of the most tedious and person-dependent tasks in Android development. In this session, we examine whether leveraging JetBrains AI Assistant—delegating everything from test-case ideation, mock injection, and test implementation generation to improvement suggestions—can accelerate development, boost test coverage, and ensure code consistency.\n\nOur focus is persistence handled by Room and asynchronous background processing with WorkManager. Engineers provide only the specifications and goals; the AI takes charge of test intent, assumptions, data design, and assertion design.\n\nCan an AI move beyond being a mere “assistant” to become an “autonomous test designer”? We will answer this through live demonstrations and an honest review of what goes wrong.\n\nOutline\n1. Challenges in writing tests\n2. Concept and setup of JetBrains AI Assistant\n3. Practice ①: Delegating Room DAO tests to the AI\n4. Practice ②: Delegating WorkManager test design to the AI\n5. Limitations of AI-driven design and work-arounds\n6. Future possibilities for autonomous development assistance\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-12T12:20:00+09:00",
+      "endsAt": "2025-09-12T13:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "4c192eda-060b-441c-9f92-424036aea2f2"
+      ],
+      "roomId": 64800,
+      "targetAudience": "・Jetpackアーキテクチャでのテストに課題を感じているAndroidエンジニア\r\n・テスト戦略や設計をAIに委ねたいと考えているモダン開発者\r\n・JetBrains製品によるAI主導型開発に興味のある方",
+      "i18nTargetAudience": {
+        "ja": "・Jetpackアーキテクチャでのテストに課題を感じているAndroidエンジニア\n・テスト戦略や設計をAIに委ねたいと考えているモダン開発者\n・JetBrains製品によるAI主導型開発に興味のある方",
+        "en": "- Android engineers who struggle with testing in the Jetpack architecture\n- Modern developers looking to delegate test strategy and design to AI\n- Anyone interested in AI-driven development with JetBrains products"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 366660,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "945222",
+      "title": {
+        "ja": "はじめてのMaterial3 Expressive",
+        "en": "Getting Started with Material3 Expressive"
+      },
+      "description": "2025年5月にGoogleは「Material3 Expressive」を発表しました。\r\nMaterial3 Expressiveは、これまでのMaterial Designとは異なる、より感情に訴える表現力豊かなUIを目指すデザインスタイルです。\r\n曲線的な形状、大胆なモーション、新たなカラーシステムなど、ビジュアルのアップデートは魅力的ですが、\r\n「プロダクトに導入するのは難しそう」と不安を感じる人も多いのではないでしょうか。\r\n\r\n本セッションでは、Material3 Expressiveの背景や思想を紹介しつつ、\r\nJetpack Composeで使えるコンポーネントの実装例を通して、\r\nUIがどのように変わるかを比較します。\r\n\r\nさらに、様々なアプリケーションをMaterial3 Expressiveで実装し、\r\nどのようなユースケースに向いているのかを検証します。\r\n\r\nGoogleのリサーチ結果や自身の検証結果を踏まえ、\r\nMaterial3 Expressiveの導入可否を判断するための観点やチーム内での議論ポイントも整理して紹介します。\r\n\r\nこのセッションを通じて、「Material3 Expressive、ちょっと試してみようかな」と思えるきっかけを提供できればと思います。\r\n\r\n具体的なセッション内容は以下を予定しています。\r\n\r\n- Material3 Expressiveとは\r\nMaterial3 Expressiveとは何か、どのようなリサーチがされてデザインされたのかなど、\r\nMaterial3 Expressiveに関するバックグラウンドについて説明します。\r\n\r\n- Material3 ExpressiveのComponent一覧\r\nMaterial3 ExpressiveでアップデートされたComponentを、実装コードと一緒に紹介します。\r\n\r\n- Material3とMaterial3 Expressiveの比較\r\n同じUIをMaterial3とMaterial3 Expressiveを使って実装し、\r\n体験や印象がどのように変化するかを比較します。\r\n\r\n- Material3 Expressiveの適したユースケース\r\nExpressiveが機能する例・機能しない例を、様々なジャンルのアプリを作って比較します。\r\n\r\n- Expressiveを導入するための判断軸\r\nチームで「Expressiveを採用する・しない」を議論するための観点について述べます。",
+      "i18nDesc": {
+        "ja": "2025年5月にGoogleは「Material3 Expressive」を発表しました。\nMaterial3 Expressiveは、これまでのMaterial Designとは異なる、より感情に訴える表現力豊かなUIを目指すデザインスタイルです。\n曲線的な形状、大胆なモーション、新たなカラーシステムなど、ビジュアルのアップデートは魅力的ですが、\n「プロダクトに導入するのは難しそう」と不安を感じる人も多いのではないでしょうか。\n\n本セッションでは、Material3 Expressiveの背景や思想を紹介しつつ、\nJetpack Composeで使えるコンポーネントの実装例を通して、\nUIがどのように変わるかを比較します。\n\nさらに、様々なアプリケーションをMaterial3 Expressiveで実装し、\nどのようなユースケースに向いているのかを検証します。\n\nGoogleのリサーチ結果や自身の検証結果を踏まえ、\nMaterial3 Expressiveの導入可否を判断するための観点やチーム内での議論ポイントも整理して紹介します。\n\nこのセッションを通じて、「Material3 Expressive、ちょっと試してみようかな」と思えるきっかけを提供できればと思います。\n\n具体的なセッション内容は以下を予定しています。\n\n- Material3 Expressiveとは\nMaterial3 Expressiveとは何か、どのようなリサーチがされてデザインされたのかなど、\nMaterial3 Expressiveに関するバックグラウンドについて説明します。\n\n- Material3 ExpressiveのComponent一覧\nMaterial3 ExpressiveでアップデートされたComponentを、実装コードと一緒に紹介します。\n\n- Material3とMaterial3 Expressiveの比較\n同じUIをMaterial3とMaterial3 Expressiveを使って実装し、\n体験や印象がどのように変化するかを比較します。\n\n- Material3 Expressiveの適したユースケース\nExpressiveが機能する例・機能しない例を、様々なジャンルのアプリを作って比較します。\n\n- Expressiveを導入するための判断軸\nチームで「Expressiveを採用する・しない」を議論するための観点について述べます。",
+        "en": "In May 2025, Google announced “Material3 Expressive,” a design style that pursues a more emotionally resonant and expressive UI than previous iterations of Material Design. Curved shapes, bold motion, and a new color system deliver an attractive visual update, yet many people may feel anxious that “bringing it into a product seems difficult.”\n\nThis session will introduce the background and philosophy of Material3 Expressive and, through implementation examples of components available in Jetpack Compose, compare how the UI changes.\n\nWe will also implement various applications with Material3 Expressive and examine which use cases it suits.\n\nDrawing on Google’s research results and our own experiments, we will organize and present viewpoints for deciding whether to adopt Material3 Expressive and discussion points within your team.\n\nThrough this session, we hope to give you a reason to think, “Maybe we should give Material3 Expressive a try.”\n\nThe planned session content is as follows.\n\n- What is Material3 Expressive\nWe will go over what Material3 Expressive is and the background research behind its design.\n\n- List of Material3 Expressive Components\nWe will introduce the components updated in Material3 Expressive along with implementation code.\n\n- Comparison of Material3 and Material3 Expressive\nWe will implement the same UI using both Material3 and Material3 Expressive and compare how the experience and impression change.\n\n- Use cases suitable for Material3 Expressive\nBy building apps across various genres, we will compare examples where Expressive works and where it does not.\n\n- Decision criteria for introducing Expressive\nWe will describe viewpoints for team discussions on whether to adopt Expressive.\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-11T15:20:00+09:00",
+      "endsAt": "2025-09-11T16:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "534d6510-eefc-4f47-9aea-f3facfdb4333"
+      ],
+      "roomId": 64802,
+      "targetAudience": "- Jetpack ComposeでのUI実装に関心のある方\r\n- Material3 Expressiveに興味がある方\r\n- Material3 Expressiveの導入を検討している方",
+      "i18nTargetAudience": {
+        "ja": "- Jetpack ComposeでのUI実装に関心のある方\n- Material3 Expressiveに興味がある方\n- Material3 Expressiveの導入を検討している方",
+        "en": "- Those interested in UI implementation with Jetpack Compose\n- Those interested in Material3 Expressive\n- Teams considering adopting Material3 Expressive"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361161,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "945497",
+      "title": {
+        "ja": "Android端末で実現するオンデバイスLLM 2025",
+        "en": "On-Device LLM on Android Devices 2025"
+      },
+      "description": "生成AIはクラウドだけのものではありません。Android 16 以降では AICore 上の Gemini Nano を ML Kit GenAI API 経由で呼び出せ、数百ms で要約・校正・画像キャプションを端末内で完結できます。一方 OSS 界隈では ggml／llama.cpp による量子化 Llama 3 などを JNI 経由で組み込む手法や、汎用ランタイム LiteRT（旧 TensorFlowLite） にモデルを変換し NNAPI／GPU で推論するルートも整備されました。\r\n\r\n本セッションでは「オフライン AI チャット」「リアルタイム文章要約」「リアルタイム文章校正」を一つの Compose アプリに統合しながら、三つのオンデバイスLLMを 同じプロンプト・同じ端末 でベンチマークします。\r\n\r\n比較軸は下記の5点です。\r\n ①導入工数とビルド手順\r\n ②モデルサイズ／RAM 使用量\r\n ③推論レイテンシ\r\n ④バッテリー消費\r\n ⑤ライセンスと運用\r\n \r\nGemini Nano の省電力性と高レベル API の手軽さ、llama.cpp の自由度と落とし穴、LiteRT の柔軟性と量子化チューニングの難しさを可視化します。\r\nまた、それぞれの実装方法同時に紹介します。\r\n\r\nオフラインでも瞬時に動き、個人情報をクラウドへ送らず、運用コストを抑えられるオンデバイスLLMは今後の発展が見込まれます。\r\n\r\n本セッションを通じて、より実用的なオンデバイスLLMを活用した Android アプリ開発のイメージを掴むことができます。実際のユースケースや実装方法を知ることで、新たなアプリの発想や、既存アプリの進化のきっかけとなることを目指します。\t",
+      "i18nDesc": {
+        "ja": "生成AIはクラウドだけのものではありません。Android 16 以降では AICore 上の Gemini Nano を ML Kit GenAI API 経由で呼び出せ、数百ms で要約・校正・画像キャプションを端末内で完結できます。一方 OSS 界隈では ggml／llama.cpp による量子化 Llama 3 などを JNI 経由で組み込む手法や、汎用ランタイム LiteRT（旧 TensorFlowLite） にモデルを変換し NNAPI／GPU で推論するルートも整備されました。\n\n本セッションでは「オフライン AI チャット」「リアルタイム文章要約」「リアルタイム文章校正」を一つの Compose アプリに統合しながら、三つのオンデバイスLLMを 同じプロンプト・同じ端末 でベンチマークします。\n\n比較軸は下記の5点です。\n①導入工数とビルド手順\n②モデルサイズ／RAM 使用量\n③推論レイテンシ\n④バッテリー消費\n⑤ライセンスと運用\n\nGemini Nano の省電力性と高レベル API の手軽さ、llama.cpp の自由度と落とし穴、LiteRT の柔軟性と量子化チューニングの難しさを可視化します。\nまた、それぞれの実装方法同時に紹介します。\n\nオフラインでも瞬時に動き、個人情報をクラウドへ送らず、運用コストを抑えられるオンデバイスLLMは今後の発展が見込まれます。\n\n本セッションを通じて、より実用的なオンデバイスLLMを活用した Android アプリ開発のイメージを掴むことができます。実際のユースケースや実装方法を知ることで、新たなアプリの発想や、既存アプリの進化のきっかけとなることを目指します。",
+        "en": "Generative AI isn’t just for the cloud. Starting with Android 16, you can invoke Gemini Nano running on AICore via the ML Kit GenAI API, completing summarization, proofreading, or image captioning entirely on-device in just a few hundred ms. In the OSS world, methods have emerged for embedding quantized Llama 3 through ggml/llama.cpp via JNI, as well as converting models for the universal runtime LiteRT (formerly TensorFlow Lite) to run inference with NNAPI/GPU.\n\nIn this session, we integrate “offline AI chat,” “real-time text summarization,” and “real-time proofreading” into a single Compose app, benchmarking three on-device LLMs with the same prompt on the same device.\n\nWe compare them across five aspects:\n1. Effort to setup and steps to build\n2. Model size/RAM usage\n3. Inference latency\n4. Battery consumption\n5. Licensing and maintenance\n\nWe will look at the power efficiency and high-level-API convenience of Gemini Nano, the flexibility and pitfalls of llama.cpp, and the versatility of LiteRT along with the challenges of quantization tuning, walking through each implementation.\n\nOn-device LLMs that respond instantly offline, keep personal data local, and cut operating costs are poised for rapid growth.\n\nBy the end of this session you’ll have a concrete picture of how to build practical Android apps powered by on-device LLMs, sparking ideas for new applications or evolutions of existing ones through real-world use cases and implementation guides.\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-11T15:20:00+09:00",
+      "endsAt": "2025-09-11T16:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "ca3b7ab1-4163-4e2d-9552-10e488af12ca"
+      ],
+      "roomId": 64799,
+      "targetAudience": "- 0からオンデバイスLLMをAndroidで実現したい方\r\n- オンデバイスLLMに興味がある方\r\n- クラウドLLM のコストやプライバシーに課題を感じている方\r\n",
+      "i18nTargetAudience": {
+        "ja": "- 0からオンデバイスLLMをAndroidで実現したい方\n- オンデバイスLLMに興味がある方\n- クラウドLLM のコストやプライバシーに課題を感じている方",
+        "en": "- Developers who want to build on-device LLMs on Android from scratch\n- Anyone interested in on-device LLMs\n- Those concerned about the cost or privacy issues of cloud-based LLMs"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 366660,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "995003",
+      "title": {
+        "ja": "意外と知らない Android と Google Play の世界",
+        "en": "The lesser‑known side of Android and Google Play"
+      },
+      "description": "Android アプリを開発するデベロッパーの皆さまに普段ご活用いただいている Google Play ですが、その裏側には、デベロッパーとユーザー双方に安全で信頼性の高いアプリ体験を届けるための、知られざる取り組みがたくさんあります。本セッションでは、「意外と知らない Android と Google Play の世界」と題し、Android および Google Play のセキュリティに対する取り組みやアプリ審査のプロセス、実は日本発のプロダクトやデベロッパーコミュニティをサポートするためのプログラムなど、普段は聞けない Android \u0026 Google Play の舞台裏をお話します。日々アプリ開発に取り組む皆さんに、新しい情報や気づきがあるはずです！",
+      "i18nDesc": {
+        "ja": "Android アプリを開発するデベロッパーの皆さまに普段ご活用いただいている Google Play ですが、その裏側には、デベロッパーとユーザー双方に安全で信頼性の高いアプリ体験を届けるための、知られざる取り組みがたくさんあります。本セッションでは、「意外と知らない Android と Google Play の世界」と題し、Android および Google Play のセキュリティに対する取り組みやアプリ審査のプロセス、実は日本発のプロダクトやデベロッパーコミュニティをサポートするためのプログラムなど、普段は聞けない Android \u0026 Google Play の舞台裏をお話します。日々アプリ開発に取り組む皆さんに、新しい情報や気づきがあるはずです！",
+        "en": "Google Play is a platform developers use every day to distribute Android apps, but behind the scenes lies a wealth of lesser‑known efforts designed to deliver a safe, reliable experience to both developers and users. In this session titled “The lesser‑known side of Android and Google Play”, we’ll explore Android and Google Play’s initiatives in security, the app review process, and programs that support Japan‑origin products and developer communities—stories you don’t hear about every day. If you\u0027re actively developing apps or involved in releasing them, this session is sure to deliver new insights and discoveries!\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-12T10:20:00+09:00",
+      "endsAt": "2025-09-12T11:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "470f8e73-18c3-415f-9b64-74fd7dbcc308"
+      ],
+      "roomId": 64801,
+      "targetAudience": "すでに Android アプリを開発し Google Play にリリースしている、もしくはこれから Android アプリの開発を検討している方\r\n事業責任者、プロダクトマネージャー、エンジニア、マーケティング など役職は問わず、Google Play の取り組みについてもっと理解を深めたい方どなたでも\r\n",
+      "i18nTargetAudience": {
+        "ja": "・すでに Android アプリを開発し Google Play にリリースしている、もしくはこれから Android アプリの開発を検討している方\n・事業責任者、プロダクトマネージャー、エンジニア、マーケティング など役職は問わず、Google Play の取り組みについてもっと理解を深めたい方どなたでも",
+        "en": "- Developers who have already released Android apps on Google Play, or are considering developing Android apps in the near future\n- Anyone—regardless of role such as engineering, product management, marketing, or business leadership—who wants to deepen their understanding of Google Play’s initiatives"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361173,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "945018",
+      "title": {
+        "ja": "Compose MultiplatformとSwiftUIで作るハイブリッドモバイルアプリ：コード共有とUI融合の実践",
+        "en": "Hybrid Mobile Apps with Compose Multiplatform and SwiftUI: Practical Code Sharing and UI Integration"
+      },
+      "description": "本セッションでは、Compose Multiplatformと各プラットフォームのネイティブUIフレームワーク（Jetpack ComposeとSwiftUI）を組み合わせたハイブリッド開発手法を解説します。実際のプロダクトでは、ビジネスロジックをKotlin Multiplatformで共有し、UI層では各プラットフォームに適したフレームワークを使い分けました。SwiftUIベースのiOSアプリにCompose Multiplatform製の画面を組み込む方法や、逆にCompose画面内でSwiftUIコンポーネント（Map等のiOSネイティブUI）を呼び出す実装テクニックを紹介します。これにより、プラットフォーム固有のUI/UX（iOSのデザイン言語や標準コンポーネント）を活かしながら、ビジネスロジックや一部UIコードの共有による効率化を実現しました。\r\n\r\nまた、コード分離の戦略として、画面やコンポーネント単位でComposeとSwiftUIのどちらで実装するかを判断する基準や、KMPで定義したViewModelから両プラットフォームのUIを扱う設計パターンにも触れます。ネイティブとクロスプラットフォームUIの共存によるメリット・デメリットを踏まえ、既存アプリへの段階的なCompose導入方法や開発フローへの影響について、実践的な知見を共有します。",
+      "i18nDesc": {
+        "ja": "本セッションでは、Compose Multiplatformと各プラットフォームのネイティブUIフレームワーク（Jetpack ComposeとSwiftUI）を組み合わせたハイブリッド開発手法を解説します。実際のプロダクトでは、ビジネスロジックをKotlin Multiplatformで共有し、UI層では各プラットフォームに適したフレームワークを使い分けました。SwiftUIベースのiOSアプリにCompose Multiplatform製の画面を組み込む方法や、逆にCompose画面内でSwiftUIコンポーネント（Map等のiOSネイティブUI）を呼び出す実装テクニックを紹介します。これにより、プラットフォーム固有のUI/UX（iOSのデザイン言語や標準コンポーネント）を活かしながら、ビジネスロジックや一部UIコードの共有による効率化を実現しました。\n\nまた、コード分離の戦略として、画面やコンポーネント単位でComposeとSwiftUIのどちらで実装するかを判断する基準や、KMPで定義したViewModelから両プラットフォームのUIを扱う設計パターンにも触れます。ネイティブとクロスプラットフォームUIの共存によるメリット・デメリットを踏まえ、既存アプリへの段階的なCompose導入方法や開発フローへの影響について、実践的な知見を共有します。",
+        "en": "In this session, we explain a hybrid development approach that combines Compose Multiplatform with each platform’s native UI frameworks—Jetpack Compose on Android and SwiftUI on iOS. In our production project, we shared business logic with Kotlin Multiplatform and chose the most suitable framework for each platform at the UI layer. We will demonstrate techniques for embedding Compose Multiplatform screens in a SwiftUI-based iOS app, and conversely invoking SwiftUI components (such as Map and other iOS-native UI) from within a Compose screen. This lets us leverage platform-specific UI/UX—iOS design language and standard components—while gaining efficiency through shared business logic and partial UI code sharing.\n\nWe will also discuss strategies for code separation: criteria for deciding whether to implement each screen or component in Compose or SwiftUI, and design patterns for controlling both UIs from a KMP-defined ViewModel. Finally, we share practical insights on the advantages and disadvantages of coexisting native and cross-platform UIs, phased Compose adoption in existing apps, and impacts on the development workflow.\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-12T16:20:00+09:00",
+      "endsAt": "2025-09-12T17:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "7c3b7d16-4c92-488b-8b18-a2d70d6d4560"
+      ],
+      "roomId": 64800,
+      "targetAudience": "Kotlin Multiplatformの導入や、ComposeとSwiftUIを組み合わせたクロスプラットフォーム開発に関心がある中級レベルのモバイルアプリ開発者。",
+      "i18nTargetAudience": {
+        "ja": "Kotlin Multiplatformの導入や、ComposeとSwiftUIを組み合わせたクロスプラットフォーム開発に関心がある中級レベルのモバイルアプリ開発者。",
+        "en": "Intermediate mobile developers interested in introducing Kotlin Multiplatform or combining Compose and SwiftUI for cross-platform development."
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361164,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "c01ebd03-5b03-435f-bcc6-c3d4a66738fa",
+      "title": {
+        "ja": "Welcome Talk",
+        "en": "Welcome Talk"
+      },
+      "description": null,
+      "i18nDesc": {
+        "ja": "Welcome Talk",
+        "en": "Welcome Talk"
+      },
+      "startsAt": "2025-09-12T10:00:00+09:00",
+      "endsAt": "2025-09-12T10:15:00+09:00",
+      "isServiceSession": true,
+      "isPlenumSession": false,
+      "speakers": [],
+      "roomId": 64803,
+      "targetAudience": "TBW",
+      "i18nTargetAudience": {
+        "ja": "TBW",
+        "en": "TBW"
+      },
+      "language": "MIXED",
+      "lengthInMinutes": 15,
+      "sessionCategoryItemId": 361173,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": false
+      }
+    },
+    {
+      "id": "932385",
+      "title": {
+        "ja": "OAuthを正しく実装する：Androidアプリのためのセキュアな認証",
+        "en": "OAuth Done Right: Secure Authentication for Android Apps"
+      },
+      "description": "OAuth 2.0 is the foundation of modern authentication in mobile apps, enabling secure access to APIs while protecting user data. However, implementing OAuth correctly in Android applications has unique security and usability challenges. From handling authentication flows efficiently to managing token security and step-up authentication, Android developers must navigate several considerations that differ from web-based implementations.\r\n\r\nIn this session, we will break down OAuth 2.0 for native Android apps, focusing on practical guidelines, security best practices, and real-world challenges. We will explore:\r\n\r\nOAuth 2.0 authentication: flows and why RFC 8252 matters for Android developers\r\nHandling tokens securely: ID Tokens, Access Tokens, Refresh Tokens, and best practices for storage\r\nStep-Up Authentication: when it is needed, and how current security recommendations guide its implementation\r\n\r\nBy the end of this session, attendees will clearly understand how to implement OAuth 2.0 securely on Android, manage tokens effectively, and leverage step-up authentication to protect sensitive user actions—without sacrificing user experience.\r\n",
+      "i18nDesc": {
+        "ja": "OAuth 2.0は、モバイルアプリにおけるモダンな認証の基盤であり、ユーザーデータを保護しつつAPIへのセキュアなアクセスを実現します。しかし、AndroidアプリケーションでOAuthを正しく実装するには、独自のセキュリティ要件やユーザビリティ上の課題があります。認証フローの効率的な処理やトークンセキュリティの管理、さらにはステップアップ認証の導入など、Android開発者はWebベースの実装とは異なるいくつかの考慮事項に対処しなければなりません。\n本セッションでは、ネイティブAndroidアプリのためのOAuth 2.0を掘り下げ、実践的なガイドライン、セキュリティのベストプラクティス、および実際の課題に焦点を当てます。具体的には以下の点に焦点を当てていきます\nOAuth 2.0認証：フローとAndroid開発者にとってRFC 8252が重要である理由\n\nトークンのセキュアな処理：IDトークン、アクセストークン、リフレッシュトークン、およびそれらの保存に関するベストプラクティス\n\nステップアップ認証：いつ必要か、そして現在のセキュリティ推奨事項がその実装をどのように導くか\n\nこのセッションの終了までに、参加者はAndroid上でユーザーエクスペリエンスを犠牲にすることなくOAuth 2.0をセキュアに実装し、トークンを適切に管理し、機密性の高いユーザーアクションを保護するためにステップアップ認証を活用する方法を明確に理解できるようになるでしょう。\n\n（DroidKaigi実行委員会による翻訳）",
+        "en": "OAuth 2.0 is the foundation of modern authentication in mobile apps, enabling secure access to APIs while protecting user data. However, implementing OAuth correctly in Android applications has unique security and usability challenges. From handling authentication flows efficiently to managing token security and step-up authentication, Android developers must navigate several considerations that differ from web-based implementations.\n\nIn this session, we will break down OAuth 2.0 for native Android apps, focusing on practical guidelines, security best practices, and real-world challenges. We will explore:\n\nOAuth 2.0 authentication: flows and why RFC 8252 matters for Android developers\nHandling tokens securely: ID Tokens, Access Tokens, Refresh Tokens, and best practices for storage\nStep-Up Authentication: when it is needed, and how current security recommendations guide its implementation\n\nBy the end of this session, attendees will clearly understand how to implement OAuth 2.0 securely on Android, manage tokens effectively, and leverage step-up authentication to protect sensitive user actions—without sacrificing user experience."
+      },
+      "startsAt": "2025-09-12T15:20:00+09:00",
+      "endsAt": "2025-09-12T16:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "84335047-a7cd-437e-986f-1d6b6df31072"
+      ],
+      "roomId": 64801,
+      "targetAudience": "All Android developers, especially those who have login functionalities in their apps.",
+      "i18nTargetAudience": {
+        "ja": "すべてのAndroid開発者、特にアプリにログイン機能を実装している開発者。",
+        "en": "All Android developers, especially those who have login functionalities in their apps."
+      },
+      "language": "ENGLISH",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361160,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": true,
+        "en": false
+      }
+    },
+    {
+      "id": "944115",
+      "title": {
+        "ja": "既存アプリをアダプティブにするには：JetStreamの場合 / Extending application adaptability: A case study of JetStream",
+        "en": "Extending application adaptability: A case study of JetStream"
+      },
+      "description": "(English version follows)\r\nJetStreamはJetpack Composeで実装されたアプリです。このアプリはもともとAndroid TV向けのサンプルでしたが、ビルドしなおさなくても様々なフォームファクター上で動作するように拡張されました。その結果、全く同じバイナリーをスマートフォンや、タブレット、折りたたみ式デバイス、Chromebook、TV、車載器、そしてXRデバイス上で動作させるという2025年のGoogle I/Oで行われたデモに利用されることとなりました。\r\n\r\nこのセッションでは、実際の開発から学んだ経験をもとに、JetStreamの開発者が既存のアプリをアダプティブに拡張するためのベストプラクティスをご説明します。具体的には、アダプティブなアプリへの拡張を行った背景や、開発の方針と進め方、どのようにフォームファクター間の差異を吸収したか、といった話題をアプリのデモを含めてお話しします。アダプティブなアプリの開発は、Androidアプリ開発にとって普通の要件となりつつあります。本セッション内容が、TVや車載器、XRデバイスといった機器への対応をお考えの方だけでなく、全てのアプリ開発者の方にとって有益なものとなれば幸いです。\r\n\r\nCompose-based JetStream, a Google I/O demo, showcases single-binary Android app adaptability across phones, foldables, tablets, desktops, TVs, cars, and XR. This session explains how JetStream, initially a TV app, was extended for various form factors by adapting to display sizes, interactions, capabilities, and guidelines. You will learn how to make apps adaptive using shareable components and abstracting form factor differences. \r\n",
+      "i18nDesc": {
+        "ja": "(English version follows)\nJetStreamはJetpack Composeで実装されたアプリです。このアプリはもともとAndroid TV向けのサンプルでしたが、ビルドしなおさなくても様々なフォームファクター上で動作するように拡張されました。その結果、全く同じバイナリーをスマートフォンや、タブレット、折りたたみ式デバイス、Chromebook、TV、車載器、そしてXRデバイス上で動作させるという2025年のGoogle I/Oで行われたデモに利用されることとなりました。\n\nこのセッションでは、実際の開発から学んだ経験をもとに、JetStreamの開発者が既存のアプリをアダプティブに拡張するためのベストプラクティスをご説明します。具体的には、アダプティブなアプリへの拡張を行った背景や、開発の方針と進め方、どのようにフォームファクター間の差異を吸収したか、といった話題をアプリのデモを含めてお話しします。アダプティブなアプリの開発は、Androidアプリ開発にとって普通の要件となりつつあります。本セッション内容が、TVや車載器、XRデバイスといった機器への対応をお考えの方だけでなく、全てのアプリ開発者の方にとって有益なものとなれば幸いです。\n\nCompose-based JetStream, a Google I/O demo, showcases single-binary Android app adaptability across phones, foldables, tablets, desktops, TVs, cars, and XR. This session explains how JetStream, initially a TV app, was extended for various form factors by adapting to display sizes, interactions, capabilities, and guidelines. You will learn how to make apps adaptive using shareable components and abstracting form factor differences.",
+        "en": "Compose-based JetStream, a Google I/O demo, showcases single-binary Android app adaptability across phones, foldables, tablets, desktops, TVs, cars, and XR. This session explains how JetStream, initially a TV app, was extended for various form factors by adapting to display sizes, interactions, capabilities, and guidelines. You will learn how to make apps adaptive using shareable components and abstracting form factor differences."
+      },
+      "startsAt": "2025-09-12T15:20:00+09:00",
+      "endsAt": "2025-09-12T16:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "c8229c07-b474-4044-af66-1c8da6779bc6"
+      ],
+      "roomId": 64800,
+      "targetAudience": "(English version follows)\r\nこのセッションは全くの初心者の方でもある程度楽しめるようにお話しします。ただサンプルコードには、ラムダやModifier、remember関数などを使用します。これらを使用した経験をお持ちであれば、よりセッションを楽しんでいただけると思います。\r\n\r\nThis session has any prerequisite, however the sample code can contain lambda, Modifiers, and remember function. ",
+      "i18nTargetAudience": {
+        "ja": "(English version follows)\nこのセッションは全くの初心者の方でもある程度楽しめるようにお話しします。ただサンプルコードには、ラムダやModifier、remember関数などを使用します。これらを使用した経験をお持ちであれば、よりセッションを楽しんでいただけると思います。\n\nThis session has any prerequisite, however the sample code can contain lambda, Modifiers, and remember function.",
+        "en": "This session has any prerequisite, however the sample code can contain lambda, Modifiers, and remember function."
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361169,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": false
+      }
+    },
+    {
+      "id": "dd102b08-e248-4a81-b14e-326642bc7880",
+      "title": {
+        "ja": "Welcome Talk",
+        "en": "Welcome Talk"
+      },
+      "description": null,
+      "i18nDesc": {
+        "ja": "Welcome Talk",
+        "en": "Welcome Talk"
+      },
+      "startsAt": "2025-09-11T10:30:00+09:00",
+      "endsAt": "2025-09-11T11:00:00+09:00",
+      "isServiceSession": true,
+      "isPlenumSession": false,
+      "speakers": [],
+      "roomId": 64803,
+      "targetAudience": "TBW",
+      "i18nTargetAudience": {
+        "ja": "TBW",
+        "en": "TBW"
+      },
+      "language": "MIXED",
+      "lengthInMinutes": 30,
+      "sessionCategoryItemId": 361173,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": false
+      }
+    },
+    {
+      "id": "928833",
+      "title": {
+        "ja": "モバイルを超えて：React NativeでAndroid AutoやAndroid TVアプリケーションを構築する",
+        "en": "Beyond Mobile: Building Android Auto and Android TV Applications with React Native"
+      },
+      "description": "React Native is increasingly adopted for mobile development, but few developers leverage it for other Android platforms. This session explores extending React Native to Android Auto and Android TV, demonstrating techniques that challenge the assumption that these platforms require fully native development.\r\nWe\u0027ll examine the unique technical constraints of non-mobile Android experiences and present a framework that bridges these gaps, enabling React Native developers to build for larger screens and automotive displays without deep platform expertise. The approach supports specialized input methods (voice commands, D-pad navigation) and platform-specific UI requirements while maintaining React Native\u0027s development efficiency.\r\nThrough practical demonstrations, you\u0027ll learn how to implement custom native modules that expose Android TV\u0027s Leanback APIs and Android Auto\u0027s messaging interfaces to JavaScript, create optimized rendering for 4K displays, and manage resources effectively in automotive environments with limited connectivity.\r\nBy the end of this session, you\u0027ll have a toolkit for expanding your React Native skills beyond smartphones to the broader Android ecosystem, opening new opportunities for cross-platform development. This solution is built on the React Native New Architecture and demonstrates performance previously thought impossible on these platforms using JavaScript frameworks.",
+      "i18nDesc": {
+        "ja": "React Nativeはモバイル開発で広く採用されていますが、他のAndroidプラットフォームで活用している開発者は少ないのが現状です。本セッションでは、React Nativeを用いて、従来「完全にネイティブ開発が必要」とされてきた Android Auto や Android TV 向けアプリに挑戦し、そうした常識を覆す手法を紹介します。\nモバイル以外のAndroidにおける独自の技術的制約を検証し、これらのギャップを埋めるためのフレームワークを提示します。これにより、React Native開発者はプラットフォーム固有の深い知識がなくても、スムーズに大画面や車載ディスプレイ向けアプリケーションを構築できるようになります。このアプローチは、React Nativeの開発効率を維持しつつ、特殊な入力方法（音声コマンド、D-padナビゲーション）やプラットフォーム固有のUI要件をサポートします。\n実践的なデモを通じて、Android TVのLeanback APIやAndroid AutoのメッセージングインターフェースをJavaScriptに公開するカスタムネイティブモジュールの実装方法、4Kディスプレイ向けに最適化されたレンダリングの作成方法、および接続が限られた車載環境でのリソースの効率的な管理方法を学びます。\nこのセッションの終了までに、スマートフォンにとどまらず、より広いAndroidエコシステムにおいてReact Nativeのスキルを拡張するためのツールキットを手に入れ、クロスプラットフォーム開発の新たな可能性を切り開くことができるでしょう。このソリューションはReact Nativeの New Architectureに基づいて構築されており、JavaScriptフレームワークでは不可能だと考えられていたこれらのプラットフォームにおける高パフォーマンスを実証します。\n\n（DroidKaigi実行委員会による翻訳）",
+        "en": "React Native is increasingly adopted for mobile development, but few developers leverage it for other Android platforms. This session explores extending React Native to Android Auto and Android TV, demonstrating techniques that challenge the assumption that these platforms require fully native development.\nWe\u0027ll examine the unique technical constraints of non-mobile Android experiences and present a framework that bridges these gaps, enabling React Native developers to build for larger screens and automotive displays without deep platform expertise. The approach supports specialized input methods (voice commands, D-pad navigation) and platform-specific UI requirements while maintaining React Native\u0027s development efficiency.\nThrough practical demonstrations, you\u0027ll learn how to implement custom native modules that expose Android TV\u0027s Leanback APIs and Android Auto\u0027s messaging interfaces to JavaScript, create optimized rendering for 4K displays, and manage resources effectively in automotive environments with limited connectivity.\nBy the end of this session, you\u0027ll have a toolkit for expanding your React Native skills beyond smartphones to the broader Android ecosystem, opening new opportunities for cross-platform development. This solution is built on the React Native New Architecture and demonstrates performance previously thought impossible on these platforms using JavaScript frameworks."
+      },
+      "startsAt": "2025-09-11T14:20:00+09:00",
+      "endsAt": "2025-09-11T15:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "abf42fb6-61a6-45fa-88fb-dbef60c194c5"
+      ],
+      "roomId": 64800,
+      "targetAudience": "React Native developers with mobile experience seeking to build apps for Android TV and Android Auto.",
+      "i18nTargetAudience": {
+        "ja": "Android TVおよびAndroid Auto向けアプリの構築を目指す、モバイル開発経験のあるReact Native開発者。",
+        "en": "React Native developers with mobile experience seeking to build apps for Android TV and Android Auto."
+      },
+      "language": "ENGLISH",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361171,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": true,
+        "en": false
+      }
+    },
+    {
+      "id": "944124",
+      "title": {
+        "ja": "基礎から学ぶ大画面対応 〜「Large screen differentiated」認定アプリの開発知見〜",
+        "en": "Learning Large-Screen Support from the Ground Up — Development Insights from a “Large screen differentiated”-Certified App —"
+      },
+      "description": "あなたのアプリは大画面対応、できていますか？\r\n\r\nAndroid 16では画面の向きやアスペクト比の指定が無視されるため、ほぼすべてのアプリで大画面対応が不可欠となりました。\r\n加えて、Android XRデバイスのようにスマホやタブレットを遥かに上回る表示領域を持つ新デバイスの登場により、大画面対応の重要性は一層増しています。\r\n\r\n私たちが開発するU-NEXTアプリは、日本のVODアプリとして初めてGoogleから「Large screen differentiated」に認定されました。\r\nこれは、Googleが定義する「Large screen app quality」の3段階評価のうち、最も高いレベルです。\r\n\r\n本セッションでは、「Large screen differentiated」対応から得られた知見を元に、既存のアプリをどのようにして「大画面対応」へと進化させるかを基礎から応用まで丁寧に解説します。\r\n\r\n既存アプリを改善したい中上級者の方はもちろん、Androidアプリ開発初心者の方にも役立つ内容です。\r\n\r\nセッションで取り上げる主なトピック：\r\n- Android 16での画面向き・アスペクト比指定の仕様変更\r\n- Googleが定義する「Large screen app quality」の概要、「Android XR app quality guidelines」との関係性\r\n- Configuration changeを考慮した設計と実装\r\n- Viewベースのアプリにおける大画面対応の戦略\r\n- Jetpack Composeを用いた柔軟な大画面対応\r\n- 「Large screen differentiated」認定を目指した、更なる大画面対応\r\n",
+      "i18nDesc": {
+        "ja": "あなたのアプリは大画面対応、できていますか？\n\nAndroid 16では画面の向きやアスペクト比の指定が無視されるため、ほぼすべてのアプリで大画面対応が不可欠となりました。\n加えて、Android XRデバイスのようにスマホやタブレットを遥かに上回る表示領域を持つ新デバイスの登場により、大画面対応の重要性は一層増しています。\n\n私たちが開発するU-NEXTアプリは、日本のVODアプリとして初めてGoogleから「Large screen differentiated」に認定されました。\nこれは、Googleが定義する「Large screen app quality」の3段階評価のうち、最も高いレベルです。\n\n本セッションでは、「Large screen differentiated」対応から得られた知見を元に、既存のアプリをどのようにして「大画面対応」へと進化させるかを基礎から応用まで丁寧に解説します。\n\n既存アプリを改善したい中上級者の方はもちろん、Androidアプリ開発初心者の方にも役立つ内容です。\n\nセッションで取り上げる主なトピック：\n- Android 16での画面向き・アスペクト比指定の仕様変更\n- Googleが定義する「Large screen app quality」の概要、「Android XR app quality guidelines」との関係性\n- Configuration changeを考慮した設計と実装\n- Viewベースのアプリにおける大画面対応の戦略\n- Jetpack Composeを用いた柔軟な大画面対応\n- 「Large screen differentiated」認定を目指した、更なる大画面対応",
+        "en": "Large screens, does your app support them?\n\nBecause Android 16 ignores fixed screen-orientation and aspect-ratio settings, virtually every app now needs to support large screens. The arrival of new form-factors with far bigger display areas—such as Android XR devices—makes large-screen readiness even more critical.\n\nOur U-NEXT app became the first Japanese VOD app to be certified by Google as “Large screen differentiated,” the highest of the three levels in Google’s Large screen app quality scale.\n\nDrawing on the knowledge gained from achieving that certification, this session explains—step by step—how to evolve an existing app into one that fully supports large screens, from fundamentals to advanced techniques.\n\nThe content will benefit intermediate and advanced developers looking to upgrade existing apps, as well as beginners who are just starting Android development.\n\nKey topics covered in the session:\n- Specification changes to screen-orientation and aspect-ratio settings in Android 16\n- Overview of Google’s Large screen app quality and its relationship to the Android XR app quality guidelines\n- Designing and implementing with configuration changes in mind\n- Strategies for large-screen support in View-based apps\n- Flexible large-screen support with Jetpack Compose\n- Going beyond to earn “Large screen differentiated” certification\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-11T11:20:00+09:00",
+      "endsAt": "2025-09-11T12:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "22eebb4b-dad2-4d32-a2db-989ac14e559c"
+      ],
+      "roomId": 64800,
+      "targetAudience": "- 大画面非対応のアプリを大画面対応したいAndroidアプリ開発者、デザイナー\r\n- Viewベースの既存アプリを大画面対応させたいが、どこから手を付ければよいか悩んでいるAndroidアプリ開発者（ 例：「Compose化を優先すべきなのか、それともViewベースのまま大画面対応すべきなのかを悩んでいる」）\r\n- Android開発を始めたばかりで、大画面対応の基本を理解したいAndroidアプリ開発初心者",
+      "i18nTargetAudience": {
+        "ja": "- 大画面非対応のアプリを大画面対応したいAndroidアプリ開発者、デザイナー\n- Viewベースの既存アプリを大画面対応させたいが、どこから手を付ければよいか悩んでいるAndroidアプリ開発者（ 例：「Compose化を優先すべきなのか、それともViewベースのまま大画面対応すべきなのかを悩んでいる」）\n- Android開発を始めたばかりで、大画面対応の基本を理解したいAndroidアプリ開発初心者",
+        "en": "- Android developers and designers who want to add large-screen support to apps that currently lack it\n- Android developers wondering where to start when adapting a View-based app for large screens (e.g., “Should I prioritize migrating to Compose, or extend large-screen support while staying View-based?”)\n- Beginners in Android development who need a foundational understanding of large-screen support"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361163,
+      "interpretationTarget": true,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "943991",
+      "title": {
+        "ja": "これでもう迷わない！Jetpack Composeの書き方実践ガイド",
+        "en": "No More Getting Lost! A Practical Guide to Writing Jetpack Compose"
+      },
+      "description": "Composeを書いていて「modifierは必ず引数にあったほうがいいのかな？複数あってもいいのかな？」「Composableを分けるときのメソッド名ってなにがベストなんだろ？」「そもそもComposableに分ける必要ってあるのか…？」\r\nこんな迷いが頭をよぎった人はいませんか？\r\n\r\n本セッションでは、Jetpack Composeを使った開発における保守性の高いUI構築のためのベストプラクティスを深掘りし、その実践ノウハウを紹介することでそんな迷いを克服します。\r\nこれらのプラクティスがなぜ重要なのか、Composeのコンポジションや再コンポジションといった内部メカニズムも交えながらお話します。\r\n具体的なコード例（推奨される書き方、避けるべきアンチパターン）を多数示し、日々の開発でこれらのプラクティスをどう活かすか、その実践的なアプローチを伝えます。\r\n\r\n発表内容予定\r\n・パフォーマンスを低下させる書き方についてとその回避策\r\n・Composableの適切な責務分割基準\r\n・Modifierの重要性と受け渡し方\r\n・主要な標準コンポーネントを使用する際のパフォーマンスやアクセシビリティに配慮した具体的な実装パターン\r\n・チーム開発での導入: これらのプラクティスをチームで共有・適用するためのコードレビューやツール活用に関するヒント",
+      "i18nDesc": {
+        "ja": "Composeを書いていて「modifierは必ず引数にあったほうがいいのかな？複数あってもいいのかな？」「Composableを分けるときのメソッド名ってなにがベストなんだろ？」「そもそもComposableに分ける必要ってあるのか…？」\nこんな迷いが頭をよぎった人はいませんか？\n\n本セッションでは、Jetpack Composeを使った開発における保守性の高いUI構築のためのベストプラクティスを深掘りし、その実践ノウハウを紹介することでそんな迷いを克服します。\nこれらのプラクティスがなぜ重要なのか、Composeのコンポジションや再コンポジションといった内部メカニズムも交えながらお話します。\n具体的なコード例（推奨される書き方、避けるべきアンチパターン）を多数示し、日々の開発でこれらのプラクティスをどう活かすか、その実践的なアプローチを伝えます。\n\n発表内容予定\n・パフォーマンスを低下させる書き方についてとその回避策\n・Composableの適切な責務分割基準\n・Modifierの重要性と受け渡し方\n・主要な標準コンポーネントを使用する際のパフォーマンスやアクセシビリティに配慮した具体的な実装パターン\n・チーム開発での導入: これらのプラクティスをチームで共有・適用するためのコードレビューやツール活用に関するヒント",
+        "en": "When writing Compose, have these thoughts ever crossed your mind? “Should I always include a modifier parameter? Is it okay to have more than one?” “What’s the best method name when I split up Composables?” or even “Do I need to split this into separate Composables at all?”\n\nThis session digs into best practices for building maintainable UIs with Jetpack Compose and shares practical know-how so you can put those doubts to rest.\nI’ll explain why these practices matter, weaving in Compose’s internals—composition and recomposition—along the way.\nWith plenty of concrete code samples (recommended patterns and anti-patterns to avoid), you’ll learn how to apply them in day-to-day development.\n\nAgenda\n- Writing patterns that hurt performance and how to avoid them\n- Criteria for properly dividing Composable responsibilities\n- The importance of Modifiers and how to pass them around\n- Concrete implementation patterns that consider performance and accessibility when using core standard components\n- Rolling this out in a team: tips on code reviews and tooling to share and apply these practices together\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-11T14:20:00+09:00",
+      "endsAt": "2025-09-11T15:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "6fb51979-7776-46e6-a090-8f1db7dd4908"
+      ],
+      "roomId": 64802,
+      "targetAudience": "・Jetpack Composeで細かい書き方に困っている人\r\n・Jetpack Composeを書いてて書き方に不安がある人",
+      "i18nTargetAudience": {
+        "ja": "・Jetpack Composeで細かい書き方に困っている人\n・Jetpack Composeを書いてて書き方に不安がある人",
+        "en": "- Developers struggling with the finer points of Jetpack Compose\n- Anyone who feels uncertain about their Jetpack Compose code"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361169,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "946622",
+      "title": {
+        "ja": "そのAPI、誰のため？ Androidライブラリ設計における利用者目線の実践テクニック",
+        "en": "Who’s this API for? Practical User-centric Techniques for Android Library Design"
+      },
+      "description": "AndroidライブラリのAPI、本当に「使いやすさ」まで考えられていますか？ 機能実装に集中するあまり、利用者の視点が抜け落ちてしまうことは少なくありません。\r\n\r\n本セッションでは、まさにそうした経験を共有します。登壇者がUIや画面遷移も含む社内認証ライブラリ開発で直面したのは、「良かれと思って設計したAPIが、実は利用側アプリのアーキテクチャやDI戦略と相性が悪かったり、ドキュメントを読み込まないと理解しづらいものだった」という現実。これこそが「作り手の論理」と「利用者のニーズ」のギャップでした。この教訓を元に、利用者にとって本当に使いやすいインターフェイスとは何か、そしてそれを実現するための具体的な設計プラクティスやコード例を、Android開発の現場目線で提案し、皆さんが明日から試せる実践的なヒントを持ち帰っていただくことを目指します。\r\n\r\n# 主なトピック\r\n\r\n・なぜインターフェイス設計にこだわるのか:\r\n　・失敗談から学ぶ、使いやすいライブラリが開発体験にもたらす影響。\r\n\r\n・利用者フレンドリーなAPI設計の実践:\r\n　・アプリのアーキテクチャとの調和: 様々なアプリ構成（MVVM、MVI、Jetpack等）に馴染む設計と、通信層（OkHttp/Retrofit等）との柔軟な連携。\r\n　・UIと画面遷移を含むライブラリのカプセル化: 社内認証ライブラリ実例から、UIやナビゲーション機能を持つライブラリをアーキテクチャ非依存でカプセル化し、アプリと連携させる工夫を深掘りします。\r\n　・DI戦略を尊重する: 利用側DI（Hilt/Koin等）を妨げず、UIを持つライブラリにも対応可能なDI非依存設計の勘所と実践。\r\n　・依存関係をシンプルに保つ: 公開APIの型選択とサードパーティ依存を隠蔽するテクニック。\r\n　・Kotlinらしさを活かす: Kotlinの言語機能（拡張関数、DSL等）で、安全かつ直感的なAPIを作るアイデア。\r\n　・Gradleモジュールと依存関係の整理: apiとimplementationの使い分けで、依存関係の見通しを改善。\r\n\r\n・継続的に改善されるライブラリのために:\r\n　・効果的なKDoc、サンプルアプリ、チームでの保守、利用者フィードバックの活用法。\r\n\r\nこのセッションが、皆さんがAndroidライブラリを開発・改善する上で、利用者にとって本当に「使いやすい」インターフェイスとは何かを改めて考えるきっかけとなり、明日からご自身のプロジェクトで試せる具体的なヒントやアイデアを持ち帰っていただくことを目指します。",
+      "i18nDesc": {
+        "ja": "AndroidライブラリのAPI、本当に「使いやすさ」まで考えられていますか？ 機能実装に集中するあまり、利用者の視点が抜け落ちてしまうことは少なくありません。\n\n本セッションでは、まさにそうした経験を共有します。登壇者がUIや画面遷移も含む社内認証ライブラリ開発で直面したのは、「良かれと思って設計したAPIが、実は利用側アプリのアーキテクチャやDI戦略と相性が悪かったり、ドキュメントを読み込まないと理解しづらいものだった」という現実。これこそが「作り手の論理」と「利用者のニーズ」のギャップでした。この教訓を元に、利用者にとって本当に使いやすいインターフェイスとは何か、そしてそれを実現するための具体的な設計プラクティスやコード例を、Android開発の現場目線で提案し、皆さんが明日から試せる実践的なヒントを持ち帰っていただくことを目指します。\n\n# 主なトピック\n\n・なぜインターフェイス設計にこだわるのか:\n ・失敗談から学ぶ、使いやすいライブラリが開発体験にもたらす影響。\n\n・利用者フレンドリーなAPI設計の実践:\n ・アプリのアーキテクチャとの調和: 様々なアプリ構成（MVVM、MVI、Jetpack等）に馴染む設計と、通信層（OkHttp/Retrofit等）との柔軟な連携。\n ・UIと画面遷移を含むライブラリのカプセル化: 社内認証ライブラリ実例から、UIやナビゲーション機能を持つライブラリをアーキテクチャ非依存でカプセル化し、アプリと連携させる工夫を深掘りします。\n ・DI戦略を尊重する: 利用側DI（Hilt/Koin等）を妨げず、UIを持つライブラリにも対応可能なDI非依存設計の勘所と実践。\n ・依存関係をシンプルに保つ: 公開APIの型選択とサードパーティ依存を隠蔽するテクニック。\n ・Kotlinらしさを活かす: Kotlinの言語機能（拡張関数、DSL等）で、安全かつ直感的なAPIを作るアイデア。\n ・Gradleモジュールと依存関係の整理: apiとimplementationの使い分けで、依存関係の見通しを改善。\n\n・継続的に改善されるライブラリのために:\n ・効果的なKDoc、サンプルアプリ、チームでの保守、利用者フィードバックの活用法。\n\nこのセッションが、皆さんがAndroidライブラリを開発・改善する上で、利用者にとって本当に「使いやすい」インターフェイスとは何かを改めて考えるきっかけとなり、明日からご自身のプロジェクトで試せる具体的なヒントやアイデアを持ち帰っていただくことを目指します。",
+        "en": "Are the APIs of your Android library truly designed with “ease of use” in mind? When we focus solely on implementing features, it’s easy to overlook the perspective of the developers who will actually consume the library.\n\nIn this session, I’ll share exactly that kind of experience. While building an in-house authentication library—including UI and navigation—we discovered that the “well-intentioned” API we had crafted clashed with consuming apps’ architectures and DI strategies, and was hard to grasp without thoroughly reading the docs. This revealed a gap between the *maker’s logic* and the *user’s needs*. Drawing on these lessons, we’ll define what a genuinely developer-friendly interface looks like and present concrete design practices and code examples from real-world Android development that you can start applying tomorrow.\n\n# Main Topics\n- Why obsess over interface design?\n - Lessons from failure and how a truly usable library elevates developer experience.\n\n- Putting consumer-friendly API design into practice:\n - Harmony with app architectures: Designing APIs that fit various structures (MVVM, MVI, Jetpack, etc.) and integrate flexibly with networking layers such as OkHttp/Retrofit.\n - Encapsulating UI and navigation: A deep dive into making a UI- and navigation-aware authentication library that remains architecture-agnostic yet easy to wire into apps.\n - Respecting DI strategies: DI-agnostic techniques that play nicely with Hilt, Koin, and other setups—even for UI-heavy libraries.\n - Keeping dependencies simple: Choosing public API types and hiding third-party dependencies.\n - Leveraging Kotlin’s strengths: Using extension functions, DSLs, and other language features to craft safe, intuitive APIs.\n - Organizing Gradle modules and dependencies: Clarifying dependency graphs with effective `api` vs `implementation` usage.\n\n- To continuously improve libraries:\n - Effective KDoc, sample apps, team maintenance workflows, and making the most of user feedback.\n\nThis session will prompt you to re-examine what makes an interface truly “easy to use” and equip you with practical tips and ideas to try in your own projects starting tomorrow.\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-12T17:20:00+09:00",
+      "endsAt": "2025-09-12T18:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "e980d068-beeb-41a3-b99d-9e9fcb92298e"
+      ],
+      "roomId": 64799,
+      "targetAudience": "・AndroidライブラリのAPI設計に課題を感じ、その使いやすさを本気で向上させたい開発者\r\n・UIや画面遷移を含む複雑な機能をライブラリ化する際の、実践的なカプセル化やアプリ連携のノウハウを知りたい方\r\n・Kotlinを活かした、よりモダンで保守性の高いライブラリ設計の具体的なヒントやアイデアを求めている開発者\r\n・チームで開発・利用するライブラリの品質とメンテナンス性に責任を持つ、または関心のある開発者",
+      "i18nTargetAudience": {
+        "ja": "・AndroidライブラリのAPI設計に課題を感じ、その使いやすさを本気で向上させたい開発者\n・UIや画面遷移を含む複雑な機能をライブラリ化する際の、実践的なカプセル化やアプリ連携のノウハウを知りたい方\n・Kotlinを活かした、よりモダンで保守性の高いライブラリ設計の具体的なヒントやアイデアを求めている開発者\n・チームで開発・利用するライブラリの品質とメンテナンス性に責任を持つ、または関心のある開発者",
+        "en": "- Developers who see room for improvement in their Android library APIs and want to boost usability\n- Those seeking practical know-how on encapsulating complex features—including UI and navigation—into libraries that integrate smoothly with apps\n- Developers looking for modern, maintainable library design techniques that leverage Kotlin\n- Engineers responsible for (or interested in) the quality and maintainability of team-developed libraries"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361164,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "945575",
+      "title": {
+        "ja": "未経験者・初心者に贈る！40分でわかるAndroidアプリ開発の今と大事なポイント",
+        "en": "For Beginners and Novices! Understand Today’s Android App Development and Key Points in 40 Minutes"
+      },
+      "description": "Androidアプリ開発は10年以上の歴史と共に、今もなお日々進化しています。SNS・ブログ・Google I/Oなどで様々な情報が飛び交います。\r\n長らくAndroidアプリ開発に携わってきたエンジニアの方々からすると、これらの変化や進化は大変嬉しいことです。\r\nしかし、Androidアプリ開発 未経験者や初心者の方はどうでしょうか？\r\n\r\n私は2021年までAndroidアプリ開発を10年間やってきましたが、その後3年間 ピュアなAndroidアプリ開発から離れていました（その間 Flutterでアプリ開発してました）。\r\nそして、2024年 3年ぶりにピュアなAndroidアプリ開発に戻ってきました。\r\n10年間の積み重ねにより基礎的な知識はありましたが、正直「色々変わっててキャッチアップするの大変なんだが！」という気持ちでした。今もそうです。\r\nこの経験を振り返った時に、積み重ねたものがない、または少ない 未経験者や初心者の方々は何を学び、何を学ばなくていいのか、見極めるだけでも一苦労するだろうと思いました。\r\n\r\n本セッションでは、Androidアプリ開発にチャレンジしたい未経験者・もっと上達したい初心者の方に向けて開発をする上で、学ぶと長く使える知識の紹介に重点を置きつつ、ちょっと古いことだから学ばなくてもいいかもしれない知識や最近のトレンドをどこまでキャッチアップすべきかなどをお話します。\r\n個人としてAndroidアプリ開発の技術力を身につけることにフォーカスした内容のため、学んだ先に見えてくる「Androidエンジニアとしてキャリアをどうするか？」、「チーム開発どうするか」などは話しません。\r\n40分と限られた時間で多くの基礎知識を扱うため、具体的な実装コードの紹介などは少なくなる想定です。コード例などは別途参照いただけるように、サンプルのリンクなどご紹介します。\r\n\r\nセッション内容のイメージをつかんでもらうために、一例として以下のようなテーマを扱います（変更の可能性はあります）\r\n- 基礎的な開発環境（Android Studio、Kotlin）\r\n- 4つのアプリコンポーネント（Activities、Services、Broadcast receivers、Content providers）\r\n- Fragmentとは？\r\n- Jetpackとは？\r\n- UIはどう作るの？ Android View or Compose\r\n- Data BindingとView Bindingの現在地\r\n- Google Play Services と Firebaseは大事\r\n- OSバージョン間の差分\r\n- 公式ドキュメントは絶対読むべき\r\n- これは学ぶべきなの？FAQ\r\n- 最新の情報はどうキャッチアップすればいいの？\r\n\r\n3年ぶりのAndroidアプリ開発を通して、私自身改めて一から学ぶ機会にめぐまれ、新しい発見や学びが多くありました。\r\nこの経験は反映した本セッションが、未経験者や初心者の方々がより楽しくAndroidアプリ開発に取り組む糧になれると嬉しいです。",
+      "i18nDesc": {
+        "ja": "Androidアプリ開発は10年以上の歴史と共に、今もなお日々進化しています。SNS・ブログ・Google I/Oなどで様々な情報が飛び交います。\n長らくAndroidアプリ開発に携わってきたエンジニアの方々からすると、これらの変化や進化は大変嬉しいことです。\nしかし、Androidアプリ開発 未経験者や初心者の方はどうでしょうか？\n\n私は2021年までAndroidアプリ開発を10年間やってきましたが、その後3年間 ピュアなAndroidアプリ開発から離れていました（その間 Flutterでアプリ開発してました）。\nそして、2024年 3年ぶりにピュアなAndroidアプリ開発に戻ってきました。\n10年間の積み重ねにより基礎的な知識はありましたが、正直「色々変わっててキャッチアップするの大変なんだが！」という気持ちでした。今もそうです。\nこの経験を振り返った時に、積み重ねたものがない、または少ない 未経験者や初心者の方々は何を学び、何を学ばなくていいのか、見極めるだけでも一苦労するだろうと思いました。\n\n本セッションでは、Androidアプリ開発にチャレンジしたい未経験者・もっと上達したい初心者の方に向けて開発をする上で、学ぶと長く使える知識の紹介に重点を置きつつ、ちょっと古いことだから学ばなくてもいいかもしれない知識や最近のトレンドをどこまでキャッチアップすべきかなどをお話します。\n個人としてAndroidアプリ開発の技術力を身につけることにフォーカスした内容のため、学んだ先に見えてくる「Androidエンジニアとしてキャリアをどうするか？」、「チーム開発どうするか」などは話しません。\n40分と限られた時間で多くの基礎知識を扱うため、具体的な実装コードの紹介などは少なくなる想定です。コード例などは別途参照いただけるように、サンプルのリンクなどご紹介します。\n\nセッション内容のイメージをつかんでもらうために、一例として以下のようなテーマを扱います（変更の可能性はあります）\n- 基礎的な開発環境（Android Studio、Kotlin）\n- 4つのアプリコンポーネント（Activities、Services、Broadcast receivers、Content providers）\n- Fragmentとは？\n- Jetpackとは？\n- UIはどう作るの？ Android View or Compose\n- Data BindingとView Bindingの現在地\n- Google Play Services と Firebaseは大事\n- OSバージョン間の差分\n- 公式ドキュメントは絶対読むべき\n- これは学ぶべきなの？FAQ\n- 最新の情報はどうキャッチアップすればいいの？\n\n3年ぶりのAndroidアプリ開発を通して、私自身改めて一から学ぶ機会にめぐまれ、新しい発見や学びが多くありました。\nこの経験は反映した本セッションが、未経験者や初心者の方々がより楽しくAndroidアプリ開発に取り組む糧になれると嬉しいです。",
+        "en": "With more than a decade of history, Android app development continues to evolve every day. News and information is abundant with social media, blogs, and Google I/O. For engineers who have long been involved in Android development, these updates and advances are wonderful. But what about people with little to no experience in Android app development?\n\nI developed Android apps for 10 years until 2021, then spent three years away from pure Android development (working with Flutter during that time). In 2024, I returned to Android development after three years. Although my decade of experience gave me a solid foundation, I honestly felt, “So much has changed—catching up is tough!” I still feel that way.\nLooking back, I realized that people with little or no accumulated knowledge will struggle even to decide what they need to learn and what they can skip.\n\nThis session focuses on those who want to try Android app development for the first time or improve their beginner-level skills. We will emphasize knowledge that will remain useful for a long time, while also touching on older topics you might safely skip and how far you should chase recent trends. Because the content centers on building personal technical skills as an Android developer, we will not cover career planning or team development.\nGiven the 40-minute limit and the breadth of foundational topics, there will be few concrete code examples; instead, we will share links to sample code for reference.\n\nTo give you an idea of the session, here are some sample themes (subject to change):\n\n- Basic development environment (Android Studio, Kotlin)\n- The four app components (Activities, Services, Broadcast receivers, Content providers)\n- What is a Fragment?\n- What is Jetpack?\n- How do you build UI? Android View or Compose\n- The current status of Data Binding and View Binding\n- Google Play Services and Firebase matter\n- Differences across OS versions\n- Definitely read the official documentation\n- Should I learn this? FAQ\n- How do you keep up with the latest information?\n\nThrough my return to Android development after three years, I had the chance to relearn everything from scratch and gained many new insights.\nI hope this session, reflecting that experience, will inspire beginners and novices to enjoy Android app development even more.\n\n(Translated by the DroidKaigi Committee)"
+      },
+      "startsAt": "2025-09-11T11:20:00+09:00",
+      "endsAt": "2025-09-11T12:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "0d134958-1519-4f3f-9c9a-b22ef94074a7"
+      ],
+      "roomId": 64802,
+      "targetAudience": "セッションを聴講するうえで必要な前提知識はありません。\r\n\r\n主に以下のような方々がメインターゲットです。\r\n- Androidアプリ開発にこれからチャレンジしたい人\r\n- Androidアプリ開発をはじめたばかりの人\r\n- Androidアプリ開発を再チャレンジしたい人\r\n- Androidアプリ開発を未経験者・初心者の方に教える人\r\n",
+      "i18nTargetAudience": {
+        "ja": "セッションを聴講するうえで必要な前提知識はありません。\n\n主に以下のような方々がメインターゲットです。\n- Androidアプリ開発にこれからチャレンジしたい人\n- Androidアプリ開発をはじめたばかりの人\n- Androidアプリ開発を再チャレンジしたい人\n- Androidアプリ開発を未経験者・初心者の方に教える人",
+        "en": "No prior knowledge is required to attend this session.\n\nThe main target audience includes:\n- People who want to start Android app development\n- People who have just begun Android app development\n- People who want to give Android app development another try\n- People who teach Android app development to beginners and novices"
+      },
+      "language": "JAPANESE",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361173,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": true
+      }
+    },
+    {
+      "id": "928111",
+      "title": {
+        "ja": "Deep dive into Kotlin Flow",
+        "en": "Deep dive into Kotlin Flow"
+      },
+      "description": "Androidアプリ開発では状態に応じた reactive UI が必須と言えます。堅牢なアプリのためにSubscription 型のデータストリームとその操作を採用することが多く、Kotlin Coroutine を使う場合は Flow と Flow operators を利用することになります。\r\n\r\nKotlin Coroutine の導入では、まるで同期的な処理文かのように非同期処理を書けることがよく取り上げられます。しかし、Flow が関わってくるとそう単純な話ではありません。特に複数の Flow が関わる場合に複雑性は上がり、Flow の呼び出し部分だけの理解では不足すると言えるでしょう。その Flow の実体クラスや upstream、また operators が巻き込んだ外部依存のすべてを包含した環境を考慮すべきです。\r\n\r\n本セッションでは既存の Flow operators の解説、custom Flow operators の実装・テスト手法及びそのポイントを話します。コードの解説やサンプルコードを通して、Flow の基礎を学ぶ機会を提供したいと思います。\r\n\r\nIn the recent Android development, the concept of Reactive UI is mandatory. Many developers have adopted subscription-based data streaming for robust softwares, and they have been using Flow from Kotlin Coroutine.\r\n\r\nAs for asynchronous programming in Kotlin Coroutine, the benefit of synchronous-like coding style is often highlighted. However, Flow doesn\u0027t always allow such simplification. In particular, orchestrated multiple Flows would be complicated. I would argue that simply understanding the subscription code of a Flow is not enough to write bug-less code. In many cases, you need to know the actual Flow class, the design of the upstream, the external dependencies involved by operator chaining and/or the entire of the running environment.\r\n\r\nIn this session, I will talk about the design/behavior of the existing Flow operators, how to implement/test new custom Flow operators, and what point should be tested. You could grasp the basics of Flow from my session.\r\n\r\nKeywords: Channel, select clause, intermediate operators, terminal operators, cashapp/turbine",
+      "i18nDesc": {
+        "ja": "Androidアプリ開発では状態に応じた reactive UI が必須と言えます。堅牢なアプリのためにSubscription 型のデータストリームとその操作を採用することが多く、Kotlin Coroutine を使う場合は Flow と Flow operators を利用することになります。\n\nKotlin Coroutine の導入では、まるで同期的な処理文かのように非同期処理を書けることがよく取り上げられます。しかし、Flow が関わってくるとそう単純な話ではありません。特に複数の Flow が関わる場合に複雑性は上がり、Flow の呼び出し部分だけの理解では不足すると言えるでしょう。その Flow の実体クラスや upstream、また operators が巻き込んだ外部依存のすべてを包含した環境を考慮すべきです。\n\n本セッションでは既存の Flow operators の解説、custom Flow operators の実装・テスト手法及びそのポイントを話します。コードの解説やサンプルコードを通して、Flow の基礎を学ぶ機会を提供したいと思います。\n\nIn the recent Android development, the concept of Reactive UI is mandatory. Many developers have adopted subscription-based data streaming for robust softwares, and they have been using Flow from Kotlin Coroutine.\n\nAs for asynchronous programming in Kotlin Coroutine, the benefit of synchronous-like coding style is often highlighted. However, Flow doesn\u0027t always allow such simplification. In particular, orchestrated multiple Flows would be complicated. I would argue that simply understanding the subscription code of a Flow is not enough to write bug-less code. In many cases, you need to know the actual Flow class, the design of the upstream, the external dependencies involved by operator chaining and/or the entire of the running environment.\n\nIn this session, I will talk about the design/behavior of the existing Flow operators, how to implement/test new custom Flow operators, and what point should be tested. You could grasp the basics of Flow from my session.\n\nKeywords: Channel, select clause, intermediate operators, terminal operators, cashapp/turbine",
+        "en": "In the recent Android development, the concept of Reactive UI is mandatory. Many developers have adopted subscription-based data streaming for robust softwares, and they have been using Flow from Kotlin Coroutine.\n\nAs for asynchronous programming in Kotlin Coroutine, the benefit of synchronous-like coding style is often highlighted. However, Flow doesn\u0027t always allow such simplification. In particular, orchestrated multiple Flows would be complicated. I would argue that simply understanding the subscription code of a Flow is not enough to write bug-less code. In many cases, you need to know the actual Flow class, the design of the upstream, the external dependencies involved by operator chaining and/or the entire of the running environment.\n\nIn this session, I will talk about the design/behavior of the existing Flow operators, how to implement/test new custom Flow operators, and what point should be tested. You could grasp the basics of Flow from my session.\n\nKeywords: Channel, select clause, intermediate operators, terminal operators, cashapp/turbine"
+      },
+      "startsAt": "2025-09-12T15:20:00+09:00",
+      "endsAt": "2025-09-12T16:00:00+09:00",
+      "isServiceSession": false,
+      "isPlenumSession": false,
+      "speakers": [
+        "65df1273-b4f7-47c9-a225-ab63a521f5b4"
+      ],
+      "roomId": 64802,
+      "targetAudience": "もうこれ以上、upstreamFlow.makeComplicated().collect { giveUp() } という気持ちになりたくない方\r\nThose who want to stop feeling like *upstreamFlow.makeComplicated().collect { giveUp() }*.",
+      "i18nTargetAudience": {
+        "ja": "もうこれ以上、upstreamFlow.makeComplicated().collect { giveUp() } という気持ちになりたくない方\nThose who want to stop feeling like *upstreamFlow.makeComplicated().collect { giveUp() }*.",
+        "en": "Those who want to stop feeling like *upstreamFlow.makeComplicated().collect { giveUp() }*."
+      },
+      "language": "ENGLISH",
+      "lengthInMinutes": 40,
+      "sessionCategoryItemId": 361159,
+      "interpretationTarget": false,
+      "asset": {
+        "videoUrl": null,
+        "slideUrl": null
+      },
+      "message": null,
+      "sessionType": "NORMAL",
+      "levels": [
+        "UNSPECIFIED"
+      ],
+      "noShow": false,
+      "translatedByCommittee": {
+        "ja": false,
+        "en": false
+      }
+    }
+  ],
+  "speakers": [
+    {
+      "id": "0d134958-1519-4f3f-9c9a-b22ef94074a7",
+      "firstName": "",
+      "lastName": "",
+      "bio": "中小企業のソフトウェア会社で複数のAndroidアプリ開発を経験した後、メルカリにて日米のAndroidアプリ開発・ソウゾウで新規事業の開発、note株式会社でnoteのアプリ開発・作業自動化、株式会社10XでDart・Flutterによる開発・EMを経験。その後、株式会社LinQにEMとして入社。whooのAndroidアプリ開発をしながら、プロダクト開発職種の採用を担当。",
+      "tagLine": "LinQ inc. Engineering Manager",
+      "profilePicture": "https://sessionize.com/image/4eba-400o400o1-3SdjhH1Zz3xvmYmgGqGAc9.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "945575"
+      ],
+      "fullName": "Shinobu Okano"
+    },
+    {
+      "id": "33dcf0cd-fb22-4f63-b2c3-0b2737576a46",
+      "firstName": "",
+      "lastName": "",
+      "bio": "RIZAP TECHNOLOGIES,Inc. で chocoZAP という Android アプリを作っています。\r\n",
+      "tagLine": "RIZAP TECHNOLOGIES,Inc.",
+      "profilePicture": "https://sessionize.com/image/9eb4-400o400o1-Wkyz7rT4xBednkSS1f2AW8.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "930808"
+      ],
+      "fullName": "Ryo Kitamura"
+    },
+    {
+      "id": "e980d068-beeb-41a3-b99d-9e9fcb92298e",
+      "firstName": "",
+      "lastName": "",
+      "bio": "サイボウズ株式会社のAndroid エンジニア。\r\nkintoneやサイボウズ OfficeのAndroidアプリを開発担当した。\r\n最近はプロダクトで利用する社内ライブラリを開発している。",
+      "tagLine": "Cybozu, Inc. Android Engineer",
+      "profilePicture": "https://sessionize.com/image/e129-400o400o1-DAjgLDduxL7d2W5RXbSnLz.png",
+      "isTopSpeaker": false,
+      "sessions": [
+        "946622"
+      ],
+      "fullName": "mkeeda"
+    },
+    {
+      "id": "8ef9d9b8-77cd-479e-bbd8-364f4f5746d0",
+      "firstName": "",
+      "lastName": "",
+      "bio": ":kodee-loving:",
+      "tagLine": "Kodee Lover | Android App Developer",
+      "profilePicture": "https://sessionize.com/image/548d-400o400o1-7pEKFjG8KRbkhrNpHaGpM8.png",
+      "isTopSpeaker": false,
+      "sessions": [
+        "946751"
+      ],
+      "fullName": "RyuNen344"
+    },
+    {
+      "id": "470f8e73-18c3-415f-9b64-74fd7dbcc308",
+      "firstName": "",
+      "lastName": "",
+      "bio": "Google Play パートナーシップチームにて、日本のデベロッパー エコシステムの成長を支援しています。Google Play 以前は、アプリ内広告ソリューション AdMob チームを約 3 年間リードしており、Google 入社前は、金融テクノロジー企業での営業経験を経てインターネットサービス企業にて戦略立案やマーケティングに従事していました。また、趣味は料理とワインで、ワイン エキスパートの資格を取得しています。",
+      "tagLine": "Google Play Partnerships  エコシステムエンゲージメント リージョナルリード 日本担当",
+      "profilePicture": "https://sessionize.com/image/7b29-400o400o1-hnNmnvHheLCMLjNAZ21Kxc.png",
+      "isTopSpeaker": false,
+      "sessions": [
+        "995003"
+      ],
+      "fullName": "Rikako Katayama"
+    },
+    {
+      "id": "ce796919-a8d8-438e-a0b6-900ac554f98e",
+      "firstName": "",
+      "lastName": "",
+      "bio": "A Google Developer Expert (GDE) for Android, Kotlin, and Firebase. He has created over 80 open-source libraries and projects, which collectively achieve more than 15 million downloads annually by developers worldwide. An author of the Manifest Android Interview book.",
+      "tagLine": "RevenueCat, Senior Developer Advocate",
+      "profilePicture": "https://sessionize.com/image/5532-400o400o1-Sp9ErY3Nz63F1ZaJTpWuLT.png",
+      "isTopSpeaker": false,
+      "sessions": [
+        "946618"
+      ],
+      "fullName": "Jaewoong (skydoves)"
+    },
+    {
+      "id": "f5d23f70-1198-46ff-b1c9-a6e6e8a9af62",
+      "firstName": "",
+      "lastName": "",
+      "bio": "Experienced Android Engineer with 10+ years of high quality development, now focused on Kotlin Multiplatform (KMM) and Compose Multiplatform (CMP).\r\nExpert in building secure, AI-driven mobile apps with modern principles and so on. ",
+      "tagLine": "Lead Android Engineer @ PayPay",
+      "profilePicture": "https://sessionize.com/image/c9f1-400o400o1-35ukAmSmiTZzA946BHcZgw.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "921565"
+      ],
+      "fullName": "AmniX"
+    },
+    {
+      "id": "bb418f1f-5970-4716-bc83-13359f40b4c1",
+      "firstName": "",
+      "lastName": "",
+      "bio": "Noman Khan is a Full Stack Software Development Engineer at Tutero and previously worked as a Software Development Engineer specializing in Flutter at Snipe, where he was also a Founding Team Member and played an integral role in shaping the company’s vision and driving development initiatives. Noman has a strong commitment to open-source development, actively participating in Google Summer of Code (GSoC): selected as a participant in 2022, serving as a mentor in 2023, and contributing as an org admin in 2024, all with The Palisadoes Foundation.",
+      "tagLine": "Software Development Engineer/Flutter Developer",
+      "profilePicture": "https://sessionize.com/image/147b-400o400o1-LUQvHRXogdHkdJb4kcbKHk.png",
+      "isTopSpeaker": false,
+      "sessions": [
+        "923086"
+      ],
+      "fullName": "Md Noman Khan"
+    },
+    {
+      "id": "be3e11c4-594c-40ae-875f-03f64536f86e",
+      "firstName": "",
+      "lastName": "",
+      "bio": "I\u0027m a graduate of Biomedical Engineering at Wrocław University of Technology. During my studies, I fell in love with programming, especially creating Android applications. I have over 5 years of commercial experience and in my spare time I\u0027m maintaining multiple open-source libraries with over 1000 monthly users.",
+      "tagLine": "Staff Software Engineer @ SpotOn",
+      "profilePicture": "https://sessionize.com/image/d3c3-400o400o1-w34gpH317YwVRZtd6gpWAP.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "939376"
+      ],
+      "fullName": "Bogusz Pawłowski"
+    },
+    {
+      "id": "e3267cf5-b1a7-4ce7-a4b3-223925f21316",
+      "firstName": "",
+      "lastName": "",
+      "bio": "Takeshi is an Android developer with a strong passion for making developers\u0027 lives easier. After working at Google, he is now pioneering the ComposeFlow project, a visual editor for Compose Multiplatform, aimed at streamlining app development.",
+      "tagLine": "ComposeFlow, founder",
+      "profilePicture": "https://sessionize.com/image/bb27-400o400o1-Jex9p6CL2mhJURxh7BjiGc.jpeg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "939784"
+      ],
+      "fullName": "thagikura"
+    },
+    {
+      "id": "66978d55-f1c2-465f-9c1c-402c4489d9c4",
+      "firstName": "",
+      "lastName": "",
+      "bio": "iOS Developer",
+      "tagLine": "STORES, Inc.",
+      "profilePicture": null,
+      "isTopSpeaker": false,
+      "sessions": [
+        "944860"
+      ],
+      "fullName": "Kenta Enomoto"
+    },
+    {
+      "id": "7c3b7d16-4c92-488b-8b18-a2d70d6d4560",
+      "firstName": "",
+      "lastName": "",
+      "bio": "モバイル＆IoT開発に10年以上従事し、現在はKINTO Technologies社でAndroidチームのアシスタントマネージャー（AM）として、バックエンド経験を活かしながらチームを牽引。THK、NHN、LG ElectronicsではそれぞれIoT、企業向けアプリ、スマートTV開発に携わってきました。",
+      "tagLine": "KINTO Technologies Corporation, Assistant Manager",
+      "profilePicture": null,
+      "isTopSpeaker": false,
+      "sessions": [
+        "945018"
+      ],
+      "fullName": "Yena Hwang"
+    },
+    {
+      "id": "87588dce-d45b-42fd-b77b-ae20e401bc53",
+      "firstName": "",
+      "lastName": "",
+      "bio": "LINEヤフー株式会社でYahoo! JAPANアプリの開発をしています．Androidアプリエンジニア，サーバーサイド(BFF)エンジニア．2024年入社．",
+      "tagLine": "LINEヤフー株式会社",
+      "profilePicture": "https://sessionize.com/image/d6bc-400o400o1-BAsXc6oNwuPKtkP8gyg87n.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "945988"
+      ],
+      "fullName": "Tetta Noguchi"
+    },
+    {
+      "id": "2f606e32-997a-4b74-8420-76a47e7d66a3",
+      "firstName": "",
+      "lastName": "",
+      "bio": "Enrique López Mañas is a Google Developer Expert and independent IT consultant. He has been working with mobile technologies and learning from them since 2007. He is an avid contributor to the open source community and a FLOSS (Free Libre Open Source Software) kind of guy, being among the top 10 open source Java contributors in Germany. He is a part of the Google LaunchPad accelerator, where he participates in Google global initiatives to influence hundreds of the best startups from all around the globe. He is also a big data and machine learning aficionado.\r\n\r\nIn his free time he rides his bike, take pictures, and travels until exhaustion. He also writes literature and enjoys all kinds of arts. He likes to write about himself in third person. You can follow him on Twitter (@eenriquelopez) to stay updated on his latest movements.",
+      "tagLine": "Google Developer Expert",
+      "profilePicture": "https://sessionize.com/image/8fa9-400o400o1-p7nSayaFDwjsf5W3ioShCx.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "946715"
+      ],
+      "fullName": "Kikoso"
+    },
+    {
+      "id": "ca3b7ab1-4163-4e2d-9552-10e488af12ca",
+      "firstName": "",
+      "lastName": "",
+      "bio": "https://github.com/MasayukiSuda",
+      "tagLine": "Software Engineer",
+      "profilePicture": "https://sessionize.com/image/3970-400o400o1-0d5754b7-c984-41af-b2b9-4e3a080a6afe.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "945497"
+      ],
+      "fullName": "daasuu"
+    },
+    {
+      "id": "7695ea9f-552f-49ac-881d-5e5c7b84fd2e",
+      "firstName": "",
+      "lastName": "",
+      "bio": "Hello, I\u0027m HyunWoo Lee from South Korea. I\u0027m working for Toss, the most popular financial super-app in South Korea.\r\nAlso I\u0027m organizer of Kotlin User Groups Seoul \u0026 GDG Korea Android.\r\n\r\nCareers \u0026 Experiences\r\n- 2024.07 ~: Android/React Native Engineer, Toss\r\n\r\n- 2024.01: Organizer, GDG(Google Developer Groups) Korea Android\r\n- 2023.10 ~ : Organizer, Kotlin User Groups Seoul\r\n- 2023.08 ~ 2024.07: Lead, GDSC(Google Developer Student Clubs) Konkuk University, South Korea\r\n- 2021.04 ~ 2023.07: Android/React Native Developer, Mathpresso Inc.(QANDA)\r\n\r\n- Speaker of DroidKnights/DroidKaigi 2024\r\n- Contributor, DroidKaigi(Japan) Conference Application\r\n- Contributor, DroidKnights(South Korea) Conference Application",
+      "tagLine": "Android/React Native Engineer, Toss",
+      "profilePicture": "https://sessionize.com/image/8764-400o400o1-B6wmHbs992NfACCJcffW4C.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "946631"
+      ],
+      "fullName": "HyunWoo Lee"
+    },
+    {
+      "id": "c8229c07-b474-4044-af66-1c8da6779bc6",
+      "firstName": "",
+      "lastName": "",
+      "bio": "Chiko is an Android Developer Relation Engineer at Google, focusing on apps on fascinating surfaces. ",
+      "tagLine": "Developer Relation Engineer, Android, Google",
+      "profilePicture": "https://sessionize.com/image/3485-400o400o1-f3SYoAGLMe2FjDDELLp3Dx.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "944115"
+      ],
+      "fullName": "Chiko"
+    },
+    {
+      "id": "422dabe0-25c9-4217-b08c-77d06630853e",
+      "firstName": "",
+      "lastName": "",
+      "bio": "I started Android development with Android 4.4 and Eclipse. Since then, I’ve worked on different kinds of Android projects. For the past six years, I’ve been at Bumble, working on various aspects of the Android development process.",
+      "tagLine": "Senior Android Engineer",
+      "profilePicture": "https://sessionize.com/image/359a-400o400o1-Shn3AoD9qR1s1zeJGfyNwR.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "944430"
+      ],
+      "fullName": "Yury Vlad"
+    },
+    {
+      "id": "a82c6942-6e2b-4d80-9883-0b84b932d6ef",
+      "firstName": "",
+      "lastName": "",
+      "bio": "As a Kotlin and Compose Multiplatform Developer Advocate at JetBrains, Sebastian spends a lot of time thinking about how technology can advance and inspire people. When he first tried Kotlin, it was love at first sight. He is one of the hosts of the Talking Kotlin podcast, and creates videos for the official Kotlin YouTube channel. Sebastian loves to develop networked applications, uses Kotlin on a variety of platforms, and passionately tinkers on his programs until late into the night.",
+      "tagLine": "Developer Advocate at JetBrains",
+      "profilePicture": "https://sessionize.com/image/2ef9-400o400o1-XGxKBoqZvxxQxosrZHQHTT.png",
+      "isTopSpeaker": false,
+      "sessions": [
+        "989391"
+      ],
+      "fullName": "Sebastian Aigner"
+    },
+    {
+      "id": "65df1273-b4f7-47c9-a225-ab63a521f5b4",
+      "firstName": "",
+      "lastName": "",
+      "bio": "A rational software engineer with a curious mind. I\u0027m currently working as Android engineer especially for IVI of vehicle units at Drivemode, Inc.",
+      "tagLine": "Drivemode, Inc.",
+      "profilePicture": "https://sessionize.com/image/f053-400o400o1-DCLP7CVwrJ52mBk8VrGdts.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "928111"
+      ],
+      "fullName": "Jumpei Matsuda"
+    },
+    {
+      "id": "5eacc5a4-dc67-408c-abab-110e92e1b866",
+      "firstName": "",
+      "lastName": "",
+      "bio": null,
+      "tagLine": "公正取引委員会　官房参事官（デジタル担当）",
+      "profilePicture": "https://sessionize.com/image/cfac-400o400o1-9p5sSjGzo995GGErCDPHWB.png",
+      "isTopSpeaker": false,
+      "sessions": [
+        "981378"
+      ],
+      "fullName": "健太 鈴木"
+    },
+    {
+      "id": "8d8bc766-ef90-487c-ac92-790f21ebccbf",
+      "firstName": "",
+      "lastName": "",
+      "bio": "UX/UIデザイナーとしてキャリアをスタートし、その後、Webフロントエンド領域でデザインエンジニアとして従事。現在はモバイルアプリ領域に軸足を移し、Android開発に挑戦中",
+      "tagLine": "Design Engineer",
+      "profilePicture": "https://sessionize.com/image/b0f6-400o400o1-PQXcVyJBLtPqaVMYMcmi3A.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "946165"
+      ],
+      "fullName": "Kanon Fujita"
+    },
+    {
+      "id": "fe4b0ef0-4120-4dd1-a432-2525d4258cd7",
+      "firstName": "",
+      "lastName": "",
+      "bio": "STORES で Android エンジニアをしています。\r\nCompose Multiplatform 製アプリ「STORES モバイルオーダー – 店舗向け注文管理」を 0からリリース、Android 先行公開から iOS 対応までの共通化を実践し、現在も開発を牽引。飲食店のオペレーションの困りごとを解決していきます！\r\n\r\nKotlin Multiplatform / Compose Multiplatform に関連した発信の実績は次のとおりです。\r\n・「KMP / CMP を使った新規プロダクトの開発」, STORES Product Blog\r\nhttps://product.st.inc/entry/2024/12/26/100000\r\n・「Compose Multiplatform 製アプリの OSS ライセンス表示」, Ebisu.mobile #9\r\nhttps://hey.connpass.com/event/347637/",
+      "tagLine": "STORES, Inc.",
+      "profilePicture": "https://sessionize.com/image/9277-400o400o1-Tymgpp5egQMNR3pzreMLna.png",
+      "isTopSpeaker": false,
+      "sessions": [
+        "944860"
+      ],
+      "fullName": "naberyo"
+    },
+    {
+      "id": "5941685d-2917-43ff-8651-02e9c3f3b0fb",
+      "firstName": "",
+      "lastName": "",
+      "bio": "クロスプラットフォームアプリ開発が得意ですがAndroid特有の機能を使い倒すのも大好きです。近年はUnityでクロスプラットフォーム開発をしています。",
+      "tagLine": "muo-ya",
+      "profilePicture": null,
+      "isTopSpeaker": false,
+      "sessions": [
+        "946620"
+      ],
+      "fullName": "muo"
+    },
+    {
+      "id": "6fb51979-7776-46e6-a090-8f1db7dd4908",
+      "firstName": "",
+      "lastName": "",
+      "bio": "2021年に株式会社サイバーエージェントに新卒入社し、Flutterアプリ開発をしていました。\r\n2025年に株式会社ZOZOに中途入社して今はAndroidアプリ開発をしています。",
+      "tagLine": "ZOZO, Inc.",
+      "profilePicture": "https://sessionize.com/image/3a01-400o400o1-7UG2tz8Td4Vxw4GuQXabbt.png",
+      "isTopSpeaker": false,
+      "sessions": [
+        "943991"
+      ],
+      "fullName": "b4tchkn"
+    },
+    {
+      "id": "5307510b-c3fa-4f9c-a340-36d198198ef5",
+      "firstName": "",
+      "lastName": "",
+      "bio": "Márton is a Kotlin Developer Advocate at JetBrains, working on making Kotlin Multiplatform awesome. Passionate about education, he\u0027s a guest lecturer at the Budapest University of Technology and Economics.\r\n\r\nHe’s been contributing to the community through writing, speaking, and open source libraries since his university days. He is a Google Developer Expert for Android and Kotlin, and a co-organizer of Android Budapest and Android Worldwide.",
+      "tagLine": "Developer Advocate @ JetBrains",
+      "profilePicture": "https://sessionize.com/image/f6d2-400o400o1-D7nt831NARhVwky31BSy5F.png",
+      "isTopSpeaker": false,
+      "sessions": [
+        "989391"
+      ],
+      "fullName": "Márton Braun"
+    },
+    {
+      "id": "4c192eda-060b-441c-9f92-424036aea2f2",
+      "firstName": "",
+      "lastName": "",
+      "bio": "Joined pixiv Inc. in 2018 as a new graduate and engaged in Android app development.",
+      "tagLine": "pixiv inc.",
+      "profilePicture": "https://sessionize.com/image/b4ae-400o400o1-KV4AoBsC4wSvB6onmgnMrX.png",
+      "isTopSpeaker": false,
+      "sessions": [
+        "940148"
+      ],
+      "fullName": "makun"
+    },
+    {
+      "id": "878813ad-5687-4a2b-8af4-be13da25eebd",
+      "firstName": "",
+      "lastName": "",
+      "bio": "Manda Edling is a UX Interaction Designer at Google working on AI interactions in Android Studio.",
+      "tagLine": "Google, UX Interaction Designer",
+      "profilePicture": "https://sessionize.com/image/3777-400o400o1-71EXv7kt8wWKduP7Tv7upJ.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "944126"
+      ],
+      "fullName": "Manda Edling"
+    },
+    {
+      "id": "2012ef2f-df29-44e5-ba09-b586c20b947b",
+      "firstName": "",
+      "lastName": "",
+      "bio": "An Android Engineer at ZOZO, Inc. (2025 New Graduate) Developing ZOZOFIT, a measurement fitness app.",
+      "tagLine": "Android Engineer",
+      "profilePicture": "https://sessionize.com/image/3d52-400o400o1-NL953r4MjZiyR8uSf4Fep6.png",
+      "isTopSpeaker": false,
+      "sessions": [
+        "943982"
+      ],
+      "fullName": "richako (risako070310)"
+    },
+    {
+      "id": "532dc16d-b69d-4f68-aa49-fe9878b0b52f",
+      "firstName": "",
+      "lastName": "",
+      "bio": "Adarsh is a Group Product Manager on Android Studio.",
+      "tagLine": "Google",
+      "profilePicture": "https://sessionize.com/image/3dde-400o400o1-e7bdf209-26ed-4e56-bbc9-8fcd0b9b5eea.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "944126"
+      ],
+      "fullName": "Adarsh Fernando"
+    },
+    {
+      "id": "b884cf72-b5c9-471b-a874-7f0ba379561d",
+      "firstName": "",
+      "lastName": "",
+      "bio": "A software engineer with extensive experience in Android development, having worked on projects that reach over 10 million users. My expertise extends to embedded systems and C2C and financial services.\r\n\r\nPassionate Advocate for Developer Communities: The Representative of TechBookFest, an event that attracts over 50,000 engineers, and I have also organized  mobile-focused conferences DroidKaigi and Kotlin Fest in Japan",
+      "tagLine": "Software Engineer, Representative of TechBookFest",
+      "profilePicture": "https://sessionize.com/image/1aa8-400o400o1-ncTxXYjnE7GdZAtwZjyfS2.png",
+      "isTopSpeaker": false,
+      "sessions": [
+        "946868"
+      ],
+      "fullName": "mhidaka"
+    },
+    {
+      "id": "abf42fb6-61a6-45fa-88fb-dbef60c194c5",
+      "firstName": "",
+      "lastName": "",
+      "bio": "I’m Aashima Wadhwa, a Software Development Engineer passionate about crafting innovative, intelligent applications. My work spans creating AI-driven systems, optimizing performance for seamless user experiences, and contributing to impactful open-source projects. I thrive on solving complex challenges, driving innovation, and building solutions that blend creativity and technology effortlessly.\r\n",
+      "tagLine": "AI Software Engineer, ScotAI",
+      "profilePicture": "https://sessionize.com/image/fd51-400o400o1-smqEK3AR4bcEZxVe93L5Dn.png",
+      "isTopSpeaker": false,
+      "sessions": [
+        "928833"
+      ],
+      "fullName": "Aashima Wadhwa"
+    },
+    {
+      "id": "8bb04227-122b-4bf8-838d-effb920fbf59",
+      "firstName": "",
+      "lastName": "",
+      "bio": "Android Engineer",
+      "tagLine": "Android Engineer",
+      "profilePicture": null,
+      "isTopSpeaker": false,
+      "sessions": [
+        "946771"
+      ],
+      "fullName": "yokomii"
+    },
+    {
+      "id": "b1ec342f-e6bf-4887-8d48-a2c5bbc017ff",
+      "firstName": "",
+      "lastName": "",
+      "bio": "Jasveen Sandral は産業用IoTシステムとクロスプラットフォーム開発に特化したソフトウェアエンジニアです。Shinmei Industryで、Web Serial APIを活用したRFID管理システムの開発に携わり、ブラウザネイティブのインターフェースを通じたデバイス通信の実現に貢献しています。\r\n\r\nオープンソースへの貢献者としても知られ、Ruby標準ライブラリにCSV::TSVクラスを実装した経験があります。この多言語環境での開発経験から、複数のテクノロジードメインを横断する視点で問題解決アプローチを提供しています。\r\n\r\nヨーロッパやアジアの技術カンファレンスで定期的に登壇し、モバイル技術の産業応用に関する実用的な知見を共有しています。コンピュータサイエンスの学位を持ち、日本語でのコミュニケーションも可能です（JLPT N3）。\r\n\r\nJasveen Sandral is a software engineer specialising in industrial IoT systems and cross-platform development. At Shinmei Industry, he has worked on RFID management systems using Web Serial API, contributing to device communication through browser-native interfaces.\r\n\r\nKnown as an open source contributor, he implemented the CSV::TSV class in Ruby\u0027s standard library. This experience working across multiple programming environments informs his unique approach to solving problems across technology domains.\r\n\r\nA regular speaker at technical conferences across Europe and Asia, Jasveen shares practical insights on industrial applications of mobile technologies. He holds a degree in Computer Science and is conversational in Japanese (JLPT N3).",
+      "tagLine": "Cross-Platform Engineer | Industrial IoT Specialist | International Technical Speaker",
+      "profilePicture": "https://sessionize.com/image/7569-400o400o1-LEs11XRyaxNZKwdMh9TKC8.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "927634"
+      ],
+      "fullName": "Jasveen Sandral"
+    },
+    {
+      "id": "ee200f6c-92ce-48c1-b2cd-19cceee38971",
+      "firstName": "",
+      "lastName": "",
+      "bio": "ロシアのシベリア出身。2016年にキャリアをスタートし、モバイルとバックエンド開発が好きで、Android開発には8年間一筋で取り込み、バックエンド開発には3年ほで携わってきた。2023年11月にピクシブに中途入社し、現在はAndroidアプリの開発を担当。KMPの信者。Observabilityのことなら無限に話せる。4649です！",
+      "tagLine": "Android Engineer @ pixiv.inc",
+      "profilePicture": "https://sessionize.com/image/272f-400o400o1-4P7rreDKQvJVMuWXU3pZjW.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "935202"
+      ],
+      "fullName": "andousan"
+    },
+    {
+      "id": "534d6510-eefc-4f47-9aea-f3facfdb4333",
+      "firstName": "",
+      "lastName": "",
+      "bio": "2024年にSTORES 株式会社にAndroidエンジニアとして入社。決済アプリの開発に従事。",
+      "tagLine": "STORES株式会社",
+      "profilePicture": null,
+      "isTopSpeaker": false,
+      "sessions": [
+        "945222"
+      ],
+      "fullName": "chuka"
+    },
+    {
+      "id": "580fb501-aece-4bf4-b755-32fda033b3bd",
+      "firstName": "",
+      "lastName": "",
+      "bio": "あんざいゆき\r\n- twitter : https://twitter.com/yanzm\r\n- blog : http://y-anz-m.blogspot.jp/ (Y.A.Mの雑記帳）\r\n- 株式会社ウフィカ\r\n- book : Master of Fragment とか\r\n",
+      "tagLine": "株式会社ウフィカ",
+      "profilePicture": "https://sessionize.com/image/8d89-400o400o1-01-aece-4bf4-b755-32fda033b3bd.b27ac996-bd96-4dcd-8be0-9acd46b4e835.png",
+      "isTopSpeaker": false,
+      "sessions": [
+        "939336"
+      ],
+      "fullName": "Yuki Anzai"
+    },
+    {
+      "id": "c3226ef8-4784-4a3c-a83d-6b70c0dcde1d",
+      "firstName": "",
+      "lastName": "",
+      "bio": "Sandra is an Android developer at DNA.inc, a remote-friendly team of experts. She’s spoken at events like Android Makers, DevFest Nantes, and several Android User Groups. After focusing on machine learning in mobile, then UI animation, she’s now looking to make the most of both worlds.",
+      "tagLine": "DNA.inc Android Developer",
+      "profilePicture": "https://sessionize.com/image/6c97-400o400o1-tezhzBjC7diTRwiMhz7NG.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "943845"
+      ],
+      "fullName": "Sandra Dupré"
+    },
+    {
+      "id": "0dece370-29a7-4e3c-a56d-83350b23c2dc",
+      "firstName": "",
+      "lastName": "",
+      "bio": "I love Compose.",
+      "tagLine": "Android Engineer",
+      "profilePicture": "https://sessionize.com/image/6e64-400o400o1-BiTAeiKAoA3RJD8yFWBQ1q.png",
+      "isTopSpeaker": false,
+      "sessions": [
+        "936837"
+      ],
+      "fullName": "usuiat"
+    },
+    {
+      "id": "ee3c097b-5c30-47e1-b311-59fb70a9724f",
+      "firstName": "",
+      "lastName": "",
+      "bio": "Android enthusiast",
+      "tagLine": "Developer Relations Engineer @ Google",
+      "profilePicture": "https://sessionize.com/image/8021-400o400o1-3FFd2hwSGpSNAH8a5MiJLb.PNG",
+      "isTopSpeaker": false,
+      "sessions": [
+        "944464"
+      ],
+      "fullName": "Sa-ryong Kang"
+    },
+    {
+      "id": "8ce6cf3a-735e-4a2a-b05f-e2081e5b6741",
+      "firstName": "",
+      "lastName": "",
+      "bio": "Zac is a mobile engineer with primary focus areas in Kotlin, OSS, Android, metaprogramming, and avoiding sniffly APIs. He’s the creator of a few open source projects like Circuit, Metro, CatchUp, AutoDispose, and active contributor to several more. Previously @ Slack, Uber, Flipboard",
+      "tagLine": "Kotlin/Mobile Person",
+      "profilePicture": "https://sessionize.com/image/52fd-400o400o1-4WUF1vht9m8eKjDP3J2x3A.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "941133"
+      ],
+      "fullName": "Zac Sweers"
+    },
+    {
+      "id": "2259b11d-cb9b-47df-a0b5-6c89fe0ce659",
+      "firstName": "",
+      "lastName": "",
+      "bio": "モバイルアプリのエンジニア。2015年からObjective-C、Swiftを用いてiOSアプリ開発に携わり、2019年からJava、Kotlinを用いてAndroidアプリ開発に携わる。2022年にはFlutterを用いて開発した経験もあり。現在の主軸はAndroid。プライベートでは2児の母。",
+      "tagLine": "株式会社ゆめみ Mobile engineer",
+      "profilePicture": "https://sessionize.com/image/d945-400o400o1-V8WHAcWf8bfCZckbRJX19v.png",
+      "isTopSpeaker": false,
+      "sessions": [
+        "944034"
+      ],
+      "fullName": "akatsuki174"
+    },
+    {
+      "id": "008463d6-4b97-43b6-94e8-48b7862c1650",
+      "firstName": "",
+      "lastName": "",
+      "bio": "2023年4月~：株式会社AbemaTVにて Android Mobile アプリの開発\r\n2024年5月~現在：同社にて Android TV アプリの開発",
+      "tagLine": "Android Developer at AbemaTV, Inc",
+      "profilePicture": "https://sessionize.com/image/26a4-400o400o1-KvqBg6fycXJ2E9BFRhrFog.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "946001"
+      ],
+      "fullName": "taked137"
+    },
+    {
+      "id": "3262db6c-d659-4109-a410-2b8dac1bf737",
+      "firstName": "",
+      "lastName": "",
+      "bio": "Music software tools enthusiast. Audio Plugins for Android, Linux, MML, MIDI 1.0/2.0, LV2. Kotlin Multiplatform.",
+      "tagLine": "androidaudioplugin.org",
+      "profilePicture": "https://sessionize.com/image/63a8-400o400o1-nR6KQNEBMmNkzPiCRF4euk.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "941476"
+      ],
+      "fullName": "atsushieno"
+    },
+    {
+      "id": "22eebb4b-dad2-4d32-a2db-989ac14e559c",
+      "firstName": "",
+      "lastName": "",
+      "bio": "株式会社U-NEXTのエンジニア。動画・電子書籍サービス「U-NEXT」のAndroidアプリ開発を担当。\r\n\r\n中学時代に初PCを自作しHSPでプログラミングに目覚め、高校・大学ではロボット競技参戦を通してマイコンプログラミング・金属加工・電子回路を学ぶ。\r\n\r\n2009年4月～2016年3月はパナソニックITS株式会社にて車載機器の組み込み開発業務に従事。ディスプレイオーディオ・カーナビ向けプラットフォーム開発、MirrorLink・CarPlay・AndroidAutoなどスマートフォン連携機能の開発を経験。\r\n\r\n2016年4月～2017年10月は株式会社SassorにてAndroidのKioskアプリやシェアサイクリングシステム・BLE連携iOSアプリなど様々な開発を牽引。\r\n\r\n2017年11月〜2021年7月は株式会社ディー・エヌ・エー（2020年4月より、事業承継で株式会社Mobility Technologiesに転籍）にて、タクシー配車サービスのAndroidアプリ開発に従事。また、組み込みデバイス開発の技術フォローをおこなう。\r\n\r\n2021年7月からは株式会社U-NEXTで動画・電子書籍サービス「U-NEXT」のAndroidアプリ開発に従事。",
+      "tagLine": "Android Engineer",
+      "profilePicture": "https://sessionize.com/image/40b7-400o400o1-D9SkWp3hCGA9uAYk5m39nC.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "944124"
+      ],
+      "fullName": "tomoya0x00"
+    },
+    {
+      "id": "c8f63f87-2370-4f36-bfce-1fea82cbcff6",
+      "firstName": "",
+      "lastName": "",
+      "bio": "chocoZAPというAndroidアプリの開発を行っています",
+      "tagLine": "RIZAP TECHNOLOGIES,Inc.",
+      "profilePicture": "https://sessionize.com/image/61e8-400o400o1-ERSKDv2nBRzNS5oHPUMFER.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "930808"
+      ],
+      "fullName": "kentaro fujii"
+    },
+    {
+      "id": "63a3dc07-8891-4cf2-b74c-15c6f626f7f3",
+      "firstName": "",
+      "lastName": "",
+      "bio": "アプリエンジニア (Android / iOS)\r\n趣味開発  (Android / iOS / Web / Windows / macOS / Ubuntu)",
+      "tagLine": "pixiv Inc.",
+      "profilePicture": "https://sessionize.com/image/db33-400o400o1-NBr4jkgTJXeu1vbg2kC2hz.png",
+      "isTopSpeaker": false,
+      "sessions": [
+        "946512"
+      ],
+      "fullName": "rokuroku"
+    },
+    {
+      "id": "64a854a3-1e09-4aa6-a8a9-2f4b8d94abfe",
+      "firstName": "",
+      "lastName": "",
+      "bio": "A software engineer at heart with a love for solving unique challenges.",
+      "tagLine": "Engineering Manager at Drivemode",
+      "profilePicture": null,
+      "isTopSpeaker": false,
+      "sessions": [
+        "946143"
+      ],
+      "fullName": "Luke Carwardine"
+    },
+    {
+      "id": "84335047-a7cd-437e-986f-1d6b6df31072",
+      "firstName": "",
+      "lastName": "",
+      "bio": "Chrystian Vieyra is an Android and iOS app developer with a specialty in visualizing sensor data. He recently transitioned to be an engineering manager at Comcast. Born in Celaya, Mexico, he immigrated to the United States to complete his B.S. in Computer Science from Western Illinois University. Chrystian resides in Washington, DC.",
+      "tagLine": "Engineering Manager",
+      "profilePicture": "https://sessionize.com/image/e02a-400o400o1-Y27vRVQocc9Y4yhBoqSAEy.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "932385"
+      ],
+      "fullName": "Chrystian Vieyra Cortes"
+    },
+    {
+      "id": "03f7318b-847b-4b2f-b016-6c9c0b3c4062",
+      "firstName": "",
+      "lastName": "",
+      "bio": "Hi, I\u0027m Seigo, an Engineering Manager overseeing Android and iOS applications development.",
+      "tagLine": "Oisix ra daichi Inc.",
+      "profilePicture": "https://sessionize.com/image/f4f6-400o400o1-UMrKUVM6acNpftacNGpzhQ.png",
+      "isTopSpeaker": false,
+      "sessions": [
+        "946204"
+      ],
+      "fullName": "ohzono"
+    },
+    {
+      "id": "ae634286-0f18-4898-9f6c-0cc2c6f645c1",
+      "firstName": "",
+      "lastName": "",
+      "bio": "Android大好き！今年からAndroidアプリ開発4年目に突入！怖いです！！",
+      "tagLine": "STORES inc. , Android developer",
+      "profilePicture": "https://sessionize.com/image/f48a-400o400o1-aaQmrqU8EAhEdyCmaiTTWV.jpg",
+      "isTopSpeaker": false,
+      "sessions": [
+        "940354"
+      ],
+      "fullName": "みっちゃん"
+    }
+  ],
+  "categories": [
+    {
+      "id": 100174,
+      "title": {
+        "ja": "カテゴリ",
+        "en": "Categories"
+      },
+      "sort": 3,
+      "items": [
+        {
+          "id": 361159,
+          "name": {
+            "ja": "Kotlin",
+            "en": "Kotlin"
+          },
+          "sort": 1
+        },
+        {
+          "id": 361160,
+          "name": {
+            "ja": "Security / Identity / Privacy",
+            "en": "Security / Identity / Privacy"
+          },
+          "sort": 2
+        },
+        {
+          "id": 361161,
+          "name": {
+            "ja": "UI・UX・デザイン",
+            "en": "UI・UX・Design"
+          },
+          "sort": 3
+        },
+        {
+          "id": 361164,
+          "name": {
+            "ja": "アプリアーキテクチャ",
+            "en": "App Architecture"
+          },
+          "sort": 4
+        },
+        {
+          "id": 361163,
+          "name": {
+            "ja": "Androidプラットフォーム",
+            "en": "Android Platform"
+          },
+          "sort": 5
+        },
+        {
+          "id": 361165,
+          "name": {
+            "ja": "保守・運用・テスト",
+            "en": "Maintenance / Operations / Testing"
+          },
+          "sort": 6
+        },
+        {
+          "id": 361166,
+          "name": {
+            "ja": "開発体制",
+            "en": "Development Process"
+          },
+          "sort": 7
+        },
+        {
+          "id": 361167,
+          "name": {
+            "ja": "Android Framework",
+            "en": "Android Framework"
+          },
+          "sort": 8
+        },
+        {
+          "id": 361168,
+          "name": {
+            "ja": "Jetpack",
+            "en": "Jetpack"
+          },
+          "sort": 9
+        },
+        {
+          "id": 361169,
+          "name": {
+            "ja": "Jetpack Compose",
+            "en": "Jetpack Compose"
+          },
+          "sort": 10
+        },
+        {
+          "id": 361170,
+          "name": {
+            "ja": "開発ツール＆サービス",
+            "en": "Development Tools and Services"
+          },
+          "sort": 11
+        },
+        {
+          "id": 361171,
+          "name": {
+            "ja": "クロスプラットフォーム",
+            "en": "Cross-platform Development"
+          },
+          "sort": 12
+        },
+        {
+          "id": 361172,
+          "name": {
+            "ja": "ソフトスキル",
+            "en": "Soft skills"
+          },
+          "sort": 13
+        },
+        {
+          "id": 366660,
+          "name": {
+            "ja": "@Experimental AI",
+            "en": "@Experimental AI"
+          },
+          "sort": 14
+        },
+        {
+          "id": 361173,
+          "name": {
+            "ja": "その他",
+            "en": "Other"
+          },
+          "sort": 15
+        }
+      ]
+    },
+    {
+      "id": 100173,
+      "title": {
+        "ja": "Session Language",
+        "en": "Session Language"
+      },
+      "sort": 2,
+      "items": [
+        {
+          "id": 361157,
+          "name": {
+            "ja": "日本語 / Japanese",
+            "en": "日本語 / Japanese"
+          },
+          "sort": 1
+        },
+        {
+          "id": 361158,
+          "name": {
+            "ja": "English",
+            "en": "English"
+          },
+          "sort": 2
+        }
+      ]
+    },
+    {
+      "id": 100172,
+      "title": {
+        "ja": "Session format",
+        "en": "Session format"
+      },
+      "sort": 1,
+      "items": [
+        {
+          "id": 361156,
+          "name": {
+            "ja": "40 minuites",
+            "en": "40 minuites"
+          },
+          "sort": 1
+        }
+      ]
+    }
+  ],
+  "questions": [
+    {
+      "id": 100171,
+      "question": {
+        "ja": "受講対象者",
+        "en": "Intended Audience"
+      },
+      "questionType": "Long_Text",
+      "sort": 0
+    }
+  ],
+  "rooms": [
+    {
+      "id": 64803,
+      "name": {
+        "ja": "Narwhal",
+        "en": "Narwhal"
+      },
+      "sort": 4
+    },
+    {
+      "id": 64801,
+      "name": {
+        "ja": "Meerkat",
+        "en": "Meerkat"
+      },
+      "sort": 3
+    },
+    {
+      "id": 64799,
+      "name": {
+        "ja": "Jellyfish",
+        "en": "Jellyfish"
+      },
+      "sort": 0
+    },
+    {
+      "id": 64802,
+      "name": {
+        "ja": "Koala",
+        "en": "Koala"
+      },
+      "sort": 1
+    },
+    {
+      "id": 64800,
+      "name": {
+        "ja": "Ladybug",
+        "en": "Ladybug"
+      },
+      "sort": 2
+    }
+  ]
+}


### PR DESCRIPTION
## 概要
Timetableのjsonデータを入れます。
[conference-app-2025](https://github.com/DroidKaigi/conference-app-2025)で使われているタイムテーブルAPIのレスポンスをそのまま入れています。
https://ssot-api.droidkaigi.jp/events/droidkaigi2025/timetable

以下のデータがあります
- session
- speaker
-  category
- room

## 動作確認
パースして適当に表示させてみましたが問題なさそうでした
<img width="480"  alt="Screenshot_20250910_210012" src="https://github.com/user-attachments/assets/9364d7c9-4032-4f65-9f2f-40f78acc07eb" />
